### PR TITLE
feat(eslint-config): wrap long comments

### DIFF
--- a/apps/backend/plugins/base.ts
+++ b/apps/backend/plugins/base.ts
@@ -19,8 +19,8 @@ async function base(
 		.setValidatorCompiler(validatorCompiler)
 		.setSerializerCompiler(serializerCompiler);
 
-	// TODO: should only be enabled for specific plugin contexts. So we may want to expose a
-	// function with these defaults at some point?
+	// TODO: should only be enabled for specific plugin contexts. So we may want to expose a function
+	// with these defaults at some point?
 
 	await app.register(fastifyMultipart, {
 		limits: {
@@ -48,8 +48,7 @@ async function base(
 		},
 		attachFieldsToBody: true,
 
-		// TODO: with these limits, we probably want to specify an 'onFile' and save temporary to
-		//  disk.
+		// TODO: with these limits, we probably want to specify an 'onFile' and save temporary to disk.
 
 		...options.multipart,
 	});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"license": "MIT",
 	"scripts": {
+		"postinstall": "patch-package",
 		"lint:ws": "npm run lint --workspaces --if-present --include-workspace-root",
 		"lint:ci:ws": "npm run lint:ci --workspaces --if-present --include-workspace-root",
 		"build:ws": "npm run build && npm run build --workspaces --if-present",
@@ -17,6 +18,7 @@
 	"devDependencies": {
 		"@lightbase/eslint-config": "0.1.0",
 		"@lightbase/tsconfig": "0.1.0",
+		"patch-package": "8.0.0",
 		"typescript": "5.4.5"
 	},
 	"engines": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,6 +31,7 @@
 		"eslint": "^8.57.0",
 		"eslint-config-flat-gitignore": "^0.1.5",
 		"eslint-import-resolver-typescript": "^3.6.1",
+		"eslint-plugin-comment-length": "1.7.3",
 		"eslint-plugin-file-progress": "^1.3.0",
 		"eslint-plugin-import-x": "^0.5.0",
 		"eslint-plugin-jsdoc": "^48.2.3",

--- a/packages/eslint-config/src/globs.ts
+++ b/packages/eslint-config/src/globs.ts
@@ -17,8 +17,7 @@ export const GLOBS = {
 };
 
 /**
- * Keep track of all used globs. We need this to use custom globs for running Prettier in
- * ESLint.
+ * Keep track of all used globs. We need this to use custom globs for running Prettier in ESLint.
  */
 export function globUse(globs: Array<string>) {
 	for (const glob of globs) {
@@ -50,9 +49,8 @@ export function globMarkdownSnippetFromGlob(glob: string) {
 }
 
 /**
- * Register all globs in use by custom configs. This is needed since we apply
- * those after the Prettier configuration. The Prettier config then uses a processor
- * to prevent parser conflicts.
+ * Register all globs in use by custom configs. This is needed since we apply those after the
+ * Prettier configuration. The Prettier config then uses a processor to prevent parser conflicts.
  */
 export function globUseFromUserConfig(...userConfigs: Array<FlatConfig.Config>) {
 	for (const conf of userConfigs) {

--- a/packages/eslint-config/src/imports.ts
+++ b/packages/eslint-config/src/imports.ts
@@ -8,8 +8,8 @@ export function imports(): Array<FlatConfig.Config> {
 	return [
 		{
 			// Setup import plugins. Includes unused-imports, to automatically remove them.
-			// This might not be the best experience if imports are added manually, but most people
-			// use auto-imports anyway (?!).
+			// This might not be the best experience if imports are added manually,
+			// but most people use auto-imports anyway (?!).
 			files: globUse([GLOBS.javascript, GLOBS.typescript]),
 			plugins: {
 				"import-x": pluginImport.default,
@@ -82,8 +82,8 @@ export function imports(): Array<FlatConfig.Config> {
 				"import-x/no-named-as-default": "off",
 				"import-x/no-named-as-default-member": "off",
 
-				// Re-enable once <https://github.com/import-js/eslint-plugin-import/issues/1479> is
-				// fixed. There is currently no related issue in eslint-plugin-import-x repo yet.
+				// Re-enable once <https://github.com/import-js/eslint-plugin-import/issues/1479> is fixed.
+				// There is currently no related issue in eslint-plugin-import-x repo yet.
 				"import-x/no-duplicates": "off",
 			},
 		},

--- a/packages/eslint-config/src/javascript.ts
+++ b/packages/eslint-config/src/javascript.ts
@@ -1,15 +1,27 @@
 import eslintConfigs from "@eslint/js";
 import typescriptEslintParser from "@typescript-eslint/parser";
 import type { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
+// @ts-expect-error no type defs
+import eslintPluginCommentLength from "eslint-plugin-comment-length";
 import pluginJsDoc from "eslint-plugin-jsdoc";
 import { GLOBS, globUse } from "./globs.js";
 import { lightbaseInternalPlugin } from "./plugin/index.js";
 
 export function javascript(): Array<FlatConfig.Config> {
+	const commentLengthOptions = {
+		mode: "overflow-only",
+		maxLength: 100,
+		logicalWrap: false,
+		tabSize: 2,
+		ignoreUrls: true,
+		ignoreCommentsWithCode: false,
+		tags: [],
+	};
+
 	return [
 		{
-			// Use the Typescript parser even if we don't Typescript. This allows us to use 'modern'
-			// JS features even if the built-in espree parser doesn't support it.
+			// Use the Typescript parser even if we don't Typescript. This allows us to use 'modern' JS
+			// features even if the built-in espree parser doesn't support it.
 			files: globUse([GLOBS.javascript]),
 			languageOptions: {
 				parser: typescriptEslintParser,
@@ -123,6 +135,18 @@ export function javascript(): Array<FlatConfig.Config> {
 					},
 				],
 				"jsdoc/valid-types": "off",
+			},
+		},
+
+		{
+			// Apply formatting on comments.
+			files: globUse([GLOBS.javascript, GLOBS.typescript]),
+			plugins: {
+				"comment-length": eslintPluginCommentLength as unknown as FlatConfig.Plugin,
+			},
+			rules: {
+				"comment-length/limit-single-line-comments": ["error", commentLengthOptions],
+				"comment-length/limit-multi-line-comments": ["error", commentLengthOptions],
 			},
 		},
 	] satisfies Array<FlatConfig.Config>;

--- a/packages/eslint-config/src/plugin/node-builtin-module-url-import.ts
+++ b/packages/eslint-config/src/plugin/node-builtin-module-url-import.ts
@@ -25,7 +25,8 @@ export const nodeBuiltinModuleUrlImport: AnyRuleModule = {
 	create(context) {
 		return {
 			ImportDeclaration(node) {
-				// Note that builtinModules doesn't include the `node:` specifier, so we automatically skip these once fixed.
+				// Note that builtinModules doesn't include the `node:` specifier, so we automatically skip
+				// these once fixed.
 				if (!builtinModules.includes(node.source.value)) {
 					return;
 				}

--- a/packages/eslint-config/src/prettier.ts
+++ b/packages/eslint-config/src/prettier.ts
@@ -37,6 +37,7 @@ export function prettierConfig(config?: PrettierConfig) {
 
 	const defaultConfig = {
 		printWidth: 90,
+		tabWidth: 2,
 		useTabs: true,
 		semi: true,
 		singleQuote: false,
@@ -52,8 +53,8 @@ export function prettierConfig(config?: PrettierConfig) {
 	};
 	config.languageOverrides ??= {};
 
-	// Dynamically add processors. We need just the original source to pass to Prettier. So if
-	// the file is already parsed by another ESLint parser, we need to create a virtual file.
+	// Dynamically add processors. We need just the original source to pass to Prettier. So if the
+	// file is already parsed by another ESLint parser, we need to create a virtual file.
 	const processors: Array<FlatConfig.Config> = [];
 	const selectGlob = (a: string, processor: FlatConfig.Processor) => {
 		if (globIsUsed(a)) {
@@ -172,11 +173,11 @@ export function prettierConfig(config?: PrettierConfig) {
 }
 
 /**
- * Make files available under a `.format` extension. This is necessary for all filetypes
- * that have a custom parser configured.
+ * Make files available under a `.format` extension. This is necessary for all filetypes that have
+ * a custom parser configured.
  *
- * ESLint only supports a single parser per file-type. Through config merging, the 'plain'
- * parser we use above would always overwrite specific parsers.
+ * ESLint only supports a single parser per file-type. Through config merging, the 'plain' parser
+ * we use above would always overwrite specific parsers.
  *
  * This is kinda hacky and not exactly sure what the consequences are yet...
  */
@@ -187,8 +188,8 @@ function formatProcessor(): FlatConfig.Processor {
 			version: "-",
 		},
 		preprocess(text: string, filename: string): Array<string | Linter.ProcessorFile> {
-			// Passes through the original file, and includes one with the `.format` prefix. This
-			// is also called a 'virtual' file.
+			// Passes through the original file, and includes one with the `.format` prefix. This is also
+			// called a 'virtual' file.
 			return [
 				text,
 				{

--- a/packages/eslint-config/src/react.ts
+++ b/packages/eslint-config/src/react.ts
@@ -14,8 +14,8 @@ export type ReactConfig = {
 };
 
 export async function react(config: ReactConfig): Promise<Array<FlatConfig.Config>> {
-	// Only expect the Next.js plugin if explicitly enabled.
-	// At some point we might infer this based on existence of the `next.config.js` file?
+	// Only expect the Next.js plugin if explicitly enabled. At some point we might infer this based
+	// on the existence of the `next.config.js` file?
 	const pluginNext =
 		config.withNextJs ?
 			(

--- a/packages/eslint-config/src/typescript.ts
+++ b/packages/eslint-config/src/typescript.ts
@@ -16,8 +16,8 @@ export type TypescriptConfig =
  * explicitly passed.
  *
  * Prefers `tsconfig.eslint.json` over `tsconfig.json`. This distinction might be necessary,
- * since typescript-eslint expects all files to be part of the compile unit, but that might
- * not be needed for normal builds.
+ * since typescript-eslint expects all files to be part of the compile unit, but that might not be
+ * needed for normal builds.
  */
 export function typescriptResolveConfig(config?: TypescriptConfig): TypescriptConfig {
 	if (config === false) {
@@ -43,9 +43,9 @@ export function typescriptResolveConfig(config?: TypescriptConfig): TypescriptCo
 			config = false;
 		}
 	} else if (config.project === undefined) {
-		// An empty options object is passed, or an options object without project. Resolve
-		// project as if nothing was passed. This means that we might disable Typescript support
-		// even if the user explicitly passed `typescript: {}`.
+		// An empty options object is passed, or an options object without project. Resolve project as
+		// if nothing was passed. This means that we might disable Typescript support even if the user
+		// explicitly passed `typescript: {}`.
 		const emptyConfigResolved = typescriptResolveConfig(undefined);
 
 		if (

--- a/patches/eslint-plugin-comment-length+1.7.3.patch
+++ b/patches/eslint-plugin-comment-length+1.7.3.patch
@@ -1,0 +1,3223 @@
+# Remove all Typescript sources from the module. According to https://github.com/microsoft/TypeScript/issues/44205#issuecomment-849895090, the module should publish .d.ts files. Since .ts files are checked with the same strictness as the configured tsconfig.json.
+# TODO: We should open an issue.
+
+diff --git a/node_modules/eslint-plugin-comment-length/src/const.message-ids.ts b/node_modules/eslint-plugin-comment-length/src/const.message-ids.ts
+deleted file mode 100644
+index 31ede7c..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/const.message-ids.ts
++++ /dev/null
+@@ -1,11 +0,0 @@
+-export enum MessageIds {
+-  EXCEEDS_MAX_LENGTH = "exceeds-max-length",
+-  CAN_COMPACT = "can-compact",
+-}
+-
+-export const reportMessages = {
+-  [MessageIds.EXCEEDS_MAX_LENGTH]:
+-    "Comments may not exceed {{maxLength}} characters",
+-  [MessageIds.CAN_COMPACT]:
+-    "It is possible to make the current comment block more compact",
+-} as const;
+diff --git a/node_modules/eslint-plugin-comment-length/src/index.ts b/node_modules/eslint-plugin-comment-length/src/index.ts
+deleted file mode 100644
+index 902ce79..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/index.ts
++++ /dev/null
+@@ -1,45 +0,0 @@
+-import type { ESLint, Linter, Rule } from "eslint";
+-
+-import { limitMultiLineCommentsRule } from "./rules/limit-multi-line-comments/rule";
+-import { limitSingleLineCommentsRule } from "./rules/limit-single-line-comments/rule";
+-import { limitTaggedTemplateLiteralCommentsRule } from "./rules/limit-tagged-template-literal-comments/rule";
+-
+-export const rules = {
+-  "limit-single-line-comments": limitSingleLineCommentsRule,
+-  "limit-multi-line-comments": limitMultiLineCommentsRule,
+-  "limit-tagged-template-literal-comments":
+-    limitTaggedTemplateLiteralCommentsRule,
+-} as unknown as Record<string, Rule.RuleModule>;
+-
+-export const configs = {
+-  recommended: {
+-    plugins: ["comment-length"],
+-    rules: {
+-      "comment-length/limit-single-line-comments": ["warn"],
+-      "comment-length/limit-multi-line-comments": ["warn"],
+-    },
+-  } satisfies ESLint.ConfigData<Linter.RulesRecord>,
+-
+-  "flat/recommended": {
+-    files: [
+-      "**/*.js",
+-      "**/*.mjs",
+-      "**/*.jsx",
+-      "**/*.ts",
+-      "**/*.mts",
+-      "**/*.tsx",
+-    ],
+-    plugins: {
+-      "comment-length": require("."),
+-    },
+-    rules: {
+-      "comment-length/limit-single-line-comments": ["warn"],
+-      "comment-length/limit-multi-line-comments": ["warn"],
+-    },
+-  } satisfies Linter.FlatConfig,
+-} as const;
+-
+-export default {
+-  rules,
+-  configs,
+-};
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/detect.overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/detect.overflow.ts
+deleted file mode 100644
+index 6be1cf4..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/detect.overflow.ts
++++ /dev/null
+@@ -1,30 +0,0 @@
+-import { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+-
+-import { Context } from "../../typings.context";
+-import { isLineOverflowing } from "../../utils/is-line-overflowing";
+-
+-import { MultilineBlock } from "./typings.block";
+-
+-export function detectOverflowInMultilineBlocks(
+-  ruleContext: RuleContext<string, unknown[]>,
+-  context: Context,
+-  blocks: MultilineBlock[],
+-) {
+-  const problematicBlocks = [] as MultilineBlock[];
+-
+-  // ... and then we can go through each block to determine if it violates
+-  // our rule to mark it as fixable using logic similar to the single-line
+-  // rule.
+-  for (const block of blocks) {
+-    for (let i = 0; i < block.lines.length; i++) {
+-      const line = block.lines[i];
+-
+-      if (line && isLineOverflowing(line, context)) {
+-        problematicBlocks.push(block);
+-        break;
+-      }
+-    }
+-  }
+-
+-  return problematicBlocks;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/docs.md b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/docs.md
+deleted file mode 100644
+index 0a7b86e..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/docs.md
++++ /dev/null
+@@ -1,181 +0,0 @@
+-
+-# `comment-length/limit-multi-line-comments`
+-
+-Locates multi-line comments, i.e. `/* comment */` and ensures that each line in the comment never exceeds the configured length.
+-
+-If a line violates this rule, the auto-fixer will attempt to combine logical groups of lines inside the comment and reformat those to ensure that each line is below the configured max length.
+-
+-As an example the comment below, which combines several comments from the `ESLint` source code, is perfectly valid:
+-
+-```ts
+-/*
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes. This allows other programs to use the CLI object and
+- * still control when the program exits.
+- *
+- * @property {("directive" | "problem" | "suggestion" | "layout")[]} [fixType] Specify the types of fixes to apply (directive, problem, suggestion, layout)
+- *
+- * @example
+- * ```tsx
+- * const someValueAfterProcessing = process(value, (node) => ({
+- *   ...node,
+- *   newProp: 2, // @TODO, insert the correct value of newProp once available here. Do note that I overflow, but do not trigger an automatic fix.
+- * }));
+- * ```
+- */
+-```
+-
+-But the following would be considered as a violation:
+-
+-```ts
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes. This allows other programs to use the CLI object and still control when the program exits.
+- */
+-```
+-
+-Which will be transformed into the snippet below when applying the automatic fix:
+-
+-```ts
+-/*
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes. This allows other programs to use the CLI object and
+- * still control when the program exits.
+- */
+-```
+-
+-## Options
+-
+-```jsonc
+-{
+-  "comment-length/limit-multi-line-comments": [
+-    "warn",
+-    {
+-      "mode": "overflow-only" | "compact-on-overflow" | "compact",
+-      "maxLength": 80,
+-      "logicalWrap": true,
+-      "ignoreUrls": true,
+-      "ignoreCommentsWithCode": true,
+-      "tabSize": 2
+-    }
+-  ]
+-}
+-```
+-
+-## Examples
+-
+-### Basic
+-
+-```ts
+-/**
+- * This is a single block.
+- * This is another block which violates the maximum length. This block will as such be automatically fixed.
+- * This is part of the previous block.
+- *
+- * This is a third block.
+- */
+-```
+-
+-```ts
+-/**
+- * This is a single block.
+- * This is another block which violates the maximum length. This block will as
+- * such be automatically fixed. This is part of the previous block.
+- *
+- * This is a third block.
+- */
+-```
+-
+-### JSDoc
+-
+-In order to preserve semantics of JSDoc-like comments the automatic fix will not apply to lines that seems to be part of a JSDoc comment (i.e. starting with the character "@").
+-
+-At times, when JSDoc declarations (e.g. @example) span multiple lines, then it may be desired to combine with the `backtick` escape-hatch described below.
+-
+-```ts
+-/**
+- * @example Here is my JSDoc-comment which will not be automatically fixable in order to avoid altering semantics.
+- */
+-```
+-
+-### Backticks
+-
+-Backticks inside a multi-line comment acts as an escape hatch for the automatic fix. In other words, all content within backticks will never be considered as a block that can be automatically fixed.
+-
+-```ts
+-/**
+- * @example
+- * ```ts
+- * Everything within backticks will not be automatically formatted. They essientially acts as an escape-hatch for the automatic fix.
+- * ```
+- */
+-```
+-
+-### Indentation
+-
+-When capturing logical blocks within a multi-line comment the rule will consider indentation levels. If two lines do not share the same indentation level, then they will never be considered as part of the same block.
+-
+-This is illustrated with the following example:
+-
+-```ts
+-/**
+- * This is a single block which overflows the default maximum line-length (80 characters).
+- *    Since this line has a different indentation level it will be considered as a separate block (which also overflows!)
+- */
+-```
+-
+-Will be fixed into:
+-
+-```ts
+-/**
+- * This is a single block which overflows the default maximum line-length (80
+- * characters).
+- *    Since this line has a different indentation level it will be considered
+- *    as a separate block (which also overflows!)
+- */
+-```
+-
+-### Single-line
+-
+-```ts
+-/** In case a multi-line comment is on a single line and it violates the configured max-length, then it will be split into multiple lines automatically. */
+-```
+-
+-Will be fixed into:
+-
+-```ts
+-/**
+- * In case a multi-line comment is on a single line and it violates the
+- * configured max-length, then it will be split into multiple lines
+- * automatically.
+- */
+-```
+-
+-### Must not be a comment with special semantics
+-
+-The comments below will NOT be automatically fixable (as this will break functionality).
+-
+-```ts
+-/** eslint-disable comment-length/limit-single-line-comments, comment-length/limit-multi-line-comments */
+-```
+-
+-### Includes a comment within the comment
+-
+-The comment below will NOT be automatically fixable as it includes a comment within itself.
+-
+-The rationale behind this decision is that developers at times will have to out-comment snippets of code when debugging. When this happens comments may also be commented out (perhaps accidentally). In this case we would like to preserve the structure of the original comment, such that when it is commented back in it follows the original layout.
+-
+-```ts
+-/** Here is my comment which // includes a very very long comment within itself. */
+-```
+-
+-### Includes a code snippet
+-
+-The comment below will NOT be automatically fixable as it includes a comment within itself.
+-
+-The rationaly is essentially the same as above. In particular we wish to avoid breaking lines when code is out-commented during debugging.
+-
+-```ts
+-/**
+- * const myVariableWhichDefinitelyOverflows = window.getComputedStyle(document.body).accentColor;
+- */
+-```
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/fix.overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/fix.overflow.ts
+deleted file mode 100644
+index bb737b9..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/fix.overflow.ts
++++ /dev/null
+@@ -1,56 +0,0 @@
+-import { TSESLint } from "@typescript-eslint/utils";
+-
+-import { Context } from "../../typings.context";
+-
+-import { MultilineBlock } from "./typings.block";
+-import { FIRST_LINE_BOILERPLATE_SIZE } from "./util.boilerplate-size";
+-import { formatBlock } from "./util.format-block";
+-
+-export function fixOverflowingBlock(
+-  fixer: TSESLint.RuleFixer,
+-  fixableBlock: MultilineBlock,
+-  context: Context,
+-) {
+-  const newValue = formatBlock(fixableBlock, context);
+-
+-  // Now, in case the entire block is only a single line
+-  // (e.g. /** text... */), then we should expand it into a multi-line
+-  // comment to preserve space.
+-  if (context.comment.lines.length === 1) {
+-    return fixer.replaceTextRange(
+-      context.comment.range,
+-      `/**\n${newValue}\n${context.whitespace.string} */`,
+-    );
+-  } else {
+-    // ... else we should simply replace the part of the comment which
+-    // overflows.
+-    const rawLines = context.comment.value.split("\n");
+-    const rangeStart =
+-      context.comment.range[0] +
+-      FIRST_LINE_BOILERPLATE_SIZE +
+-      rawLines.slice(0, fixableBlock.startIndex).join("\n").length;
+-    const rangeEnd =
+-      context.comment.range[0] +
+-      FIRST_LINE_BOILERPLATE_SIZE -
+-      1 +
+-      rawLines.slice(0, fixableBlock.endIndex + 1).join("\n").length;
+-
+-    let paddedValue = newValue;
+-
+-    // and, in the rare case where the violating block starts on
+-    // the same line as the start of the multi-comment
+-    // (i.e. /** my-comment...), then move it down to the next line,
+-    // to maximize the available space.
+-    if (fixableBlock.startIndex === 0) {
+-      paddedValue = `\n${paddedValue}`;
+-    }
+-
+-    // ... and ensure that the end of the comment is actually pushed to the
+-    // final line if it isn't already.
+-    if (fixableBlock.endIndex === rawLines.length - 1) {
+-      paddedValue = `${paddedValue}\n${context.whitespace.string} `;
+-    }
+-
+-    return fixer.replaceTextRange([rangeStart, rangeEnd], paddedValue);
+-  }
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/report.compact.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/report.compact.ts
+deleted file mode 100644
+index 555966e..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/report.compact.ts
++++ /dev/null
+@@ -1,47 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-import { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+-
+-import { MessageIds } from "../../const.message-ids";
+-import { Context } from "../../typings.context";
+-
+-import { fixOverflowingBlock } from "./fix.overflow";
+-import { MultilineBlock } from "./typings.block";
+-import { canBlockBeCompated } from "./util.can-block-be-compacted";
+-
+-export function reportCompactableBlocks(
+-  ruleContext: RuleContext<string, unknown[]>,
+-  baseComment: TSESTree.BlockComment,
+-  context: Context,
+-  blocks: MultilineBlock[],
+-) {
+-  if (context.mode !== "compact") {
+-    return;
+-  }
+-
+-  for (const block of blocks) {
+-    if (!canBlockBeCompated(block, context)) {
+-      continue;
+-    }
+-
+-    ruleContext.report({
+-      loc: {
+-        start: {
+-          column: 0,
+-          line: baseComment.loc.start.line + block.startIndex,
+-        },
+-        end: {
+-          column:
+-            baseComment.loc.start.column +
+-            context.boilerplateSize +
+-            (block.lines.at(-1)?.length ?? 0),
+-          line: baseComment.loc.start.line + block.endIndex,
+-        },
+-      },
+-      messageId: MessageIds.CAN_COMPACT,
+-      data: {
+-        maxLength: context.maxLength,
+-      },
+-      fix: (fixer) => fixOverflowingBlock(fixer, block, context),
+-    });
+-  }
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/report.overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/report.overflow.ts
+deleted file mode 100644
+index 4fe14e7..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/report.overflow.ts
++++ /dev/null
+@@ -1,40 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-import { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+-
+-import { MessageIds } from "../../const.message-ids";
+-import { Context } from "../../typings.context";
+-
+-import { fixOverflowingBlock } from "./fix.overflow";
+-import { MultilineBlock } from "./typings.block";
+-
+-export function reportOverflowingBlocks(
+-  ruleContext: RuleContext<string, unknown[]>,
+-  baseComment: TSESTree.BlockComment,
+-  context: Context,
+-  overflowingBlocks: MultilineBlock[],
+-) {
+-  for (const fixableBlock of overflowingBlocks) {
+-    ruleContext.report({
+-      // Ensure we only highlight exactly the block within the multi-line
+-      // comment which violates the rule.
+-      loc: {
+-        start: {
+-          column: 0,
+-          line: baseComment.loc.start.line + fixableBlock.startIndex,
+-        },
+-        end: {
+-          column:
+-            baseComment.loc.start.column +
+-            context.boilerplateSize +
+-            (fixableBlock.lines.at(-1)?.length ?? 0),
+-          line: baseComment.loc.start.line + fixableBlock.endIndex,
+-        },
+-      },
+-      messageId: MessageIds.EXCEEDS_MAX_LENGTH,
+-      data: {
+-        maxLength: context.maxLength,
+-      },
+-      fix: (fixer) => fixOverflowingBlock(fixer, fixableBlock, context),
+-    });
+-  }
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/root.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/root.ts
+deleted file mode 100644
+index 1e06f93..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/root.ts
++++ /dev/null
+@@ -1,99 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-import { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+-
+-import { Context } from "../../typings.context";
+-import { Options } from "../../typings.options";
+-import { isCodeInComment } from "../../utils/is-code-in-comment";
+-import { isCommentInComment } from "../../utils/is-comment-in-comment";
+-import { isJSDocLikeComment } from "../../utils/is-jsdoc-like";
+-import { isCommentOnOwnLine } from "../../utils/is-on-own-line";
+-import { isSemanticComment } from "../../utils/is-semantic-comment";
+-
+-import { detectOverflowInMultilineBlocks } from "./detect.overflow";
+-import { reportCompactableBlocks } from "./report.compact";
+-import { reportOverflowingBlocks } from "./report.overflow";
+-import { getBoilerPlateSize } from "./util.boilerplate-size";
+-import { extractBlocksFromMultilineComment } from "./util.extract-blocks";
+-
+-export function limitMultiLineComments(
+-  ruleContext: RuleContext<string, unknown[]>,
+-  options: Options,
+-  comments: TSESTree.Comment[],
+-) {
+-  const sourceCode = ruleContext.getSourceCode();
+-  const lines = sourceCode.getLines();
+-
+-  for (const comment of comments) {
+-    const commentRange = comment.range;
+-
+-    if (
+-      !commentRange ||
+-      !comment.loc ||
+-      comment.type !== "Block" ||
+-      !isCommentOnOwnLine(sourceCode, comment) ||
+-      isSemanticComment(comment)
+-    ) {
+-      continue;
+-    }
+-
+-    const whitespaceString = (() => {
+-      const firstLine = lines[comment.loc.start.line - 1];
+-      const lastLine = lines[comment.loc.end.line - 1];
+-
+-      if (
+-        comment.loc.start.line === comment.loc.end.line ||
+-        (lastLine && !/^( |\t)*\*\//.test(lastLine))
+-      ) {
+-        return firstLine?.split("/*")[0] ?? "";
+-      }
+-
+-      return lastLine?.split(" */")[0] ?? firstLine?.split("/*")[0] ?? "";
+-    })();
+-
+-    const commentLines = getCommentLines(comment);
+-    const context = {
+-      ...options,
+-      whitespace: {
+-        string: whitespaceString,
+-        size: whitespaceString
+-          .split("")
+-          .reduce(
+-            (acc, curr) => acc + (curr === "\t" ? options.tabSize : 1),
+-            0,
+-          ),
+-      },
+-      boilerplateSize: getBoilerPlateSize(commentLines),
+-      comment: {
+-        range: commentRange,
+-        lines: commentLines,
+-        value: comment.value,
+-      },
+-    } satisfies Context;
+-
+-    // Extract all valid blocks, but immediately remove those that should be
+-    // ignored no matter what.
+-    const blocks = extractBlocksFromMultilineComment(context).filter(
+-      (block) =>
+-        !block.lines.some(
+-          (line) => isCommentInComment(line) || isJSDocLikeComment(line),
+-        ) && !isCodeInComment(block.value, ruleContext.parserPath, context),
+-    );
+-
+-    const overflowingBlocks = detectOverflowInMultilineBlocks(
+-      ruleContext,
+-      context,
+-      blocks,
+-    );
+-
+-    reportOverflowingBlocks(ruleContext, comment, context, overflowingBlocks);
+-
+-    const remainingBlocks = blocks.filter(
+-      (it) => !overflowingBlocks.includes(it),
+-    );
+-    reportCompactableBlocks(ruleContext, comment, context, remainingBlocks);
+-  }
+-}
+-
+-function getCommentLines(comment: TSESTree.BlockComment): string[] {
+-  return comment.value.split("\n").map((it) => it.replace(/^( |\t)*?\*/, ""));
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/rule.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/rule.ts
+deleted file mode 100644
+index b27166f..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/rule.ts
++++ /dev/null
+@@ -1,38 +0,0 @@
+-import { ESLintUtils } from "@typescript-eslint/utils";
+-
+-import { MessageIds, reportMessages } from "../../const.message-ids";
+-import {
+-  RuleOptions,
+-  defaultOptions,
+-  optionsSchema,
+-} from "../../typings.options";
+-import { resolveDocsRoute } from "../../utils/resolve-docs-route";
+-
+-import { limitMultiLineComments } from "./root";
+-
+-const createRule = ESLintUtils.RuleCreator(resolveDocsRoute);
+-
+-export const limitMultiLineCommentsRule = createRule<RuleOptions, MessageIds>({
+-  name: "limit-multi-line-comments",
+-  defaultOptions,
+-  meta: {
+-    type: "layout",
+-    fixable: "whitespace",
+-    messages: reportMessages,
+-    docs: {
+-      description:
+-        "Reflows multi-line comments to ensure that blocks never exceed the configured length",
+-      recommended: "stylistic",
+-    },
+-    schema: optionsSchema,
+-  },
+-
+-  create: (ruleContext, [options]) => {
+-    const sourceCode = ruleContext.getSourceCode();
+-    const comments = sourceCode.getAllComments();
+-
+-    limitMultiLineComments(ruleContext, options, comments);
+-
+-    return {};
+-  },
+-});
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/_tests.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/_tests.ts
+deleted file mode 100644
+index 3820760..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/_tests.ts
++++ /dev/null
+@@ -1,150 +0,0 @@
+-import path from "path";
+-
+-import { getCode } from "../../../utils/testing.get-code";
+-
+-import { limitMultiLineCommentsRule } from "../rule";
+-import { defaultOptions } from "../../../typings.options";
+-import { MessageIds } from "../../../const.message-ids";
+-import { RuleTester } from "@typescript-eslint/utils/ts-eslint";
+-
+-const ruleTester = new RuleTester({
+-  parser: require("@typescript-eslint/parser"),
+-  parserOptions: {
+-    project: "./tsconfig.test.json",
+-    tsconfigRootDir: path.resolve(__dirname, "..", "..", "..", ".."),
+-    ecmaFeatures: {
+-      jsx: true,
+-    },
+-  },
+-  env: {
+-    browser: true,
+-    es2023: true,
+-    node: true,
+-  },
+-});
+-
+-ruleTester.run("limit-multi-line-comments", limitMultiLineCommentsRule, {
+-  valid: [
+-    getCode(__dirname, "valid.basic", defaultOptions),
+-    getCode(__dirname, "valid.jsdoc", defaultOptions),
+-    getCode(__dirname, "valid.oneline-jsdoc", defaultOptions),
+-    getCode(__dirname, "valid.oneline-jsdoc", [
+-      {
+-        ...defaultOptions[0],
+-        mode: "compact",
+-      },
+-    ] as const),
+-    getCode(__dirname, "valid.jsdoc-compact", [
+-      {
+-        ...defaultOptions[0],
+-        mode: "compact",
+-      },
+-    ] as const),
+-    getCode(__dirname, "valid.backticks", defaultOptions),
+-    getCode(__dirname, "valid.semantic", defaultOptions),
+-    getCode(__dirname, "valid.exactly-80", defaultOptions),
+-    getCode(__dirname, "valid.comment-within-comment", defaultOptions),
+-    getCode(__dirname, "option.code-within", [
+-      {
+-        ...defaultOptions[0],
+-        ignoreCommentsWithCode: true,
+-      },
+-    ] as const),
+-    getCode(__dirname, "option.no-urls", defaultOptions),
+-    getCode(__dirname, "option.compact", [
+-      {
+-        ...defaultOptions[0],
+-        mode: "compact-on-overflow",
+-      },
+-    ] as const),
+-  ],
+-  invalid: [
+-    getCode(
+-      __dirname,
+-      "invalid.basic-overflow",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "invalid.indentation",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "invalid.single-line",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "invalid.multiple-lines",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "invalid.malformed",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "invalid.final-line",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.max-length20",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          maxLength: 20,
+-        },
+-      ] as const,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.code-within",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          ignoreCommentsWithCode: false,
+-        },
+-      ] as const,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.no-urls",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          ignoreUrls: false,
+-        },
+-      ] as const,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.compact",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          mode: "compact",
+-        },
+-      ] as const,
+-      MessageIds.CAN_COMPACT
+-    ),
+-    getCode(__dirname, "option.logical-wrap", [
+-      {
+-        ...defaultOptions[0],
+-        logicalWrap: true
+-      }
+-    ] as const,
+-    MessageIds.EXCEEDS_MAX_LENGTH),
+-  ],
+-});
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.basic-overflow.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.basic-overflow.expected.ts
+deleted file mode 100644
+index 7882719..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.basic-overflow.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes.
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.basic-overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.basic-overflow.ts
+deleted file mode 100644
+index 8fd8724..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.basic-overflow.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes.
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.final-line.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.final-line.expected.ts
+deleted file mode 100644
+index f6e5593..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.final-line.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-          /**
+-   * clearly working comment, that is way too long to fit on a singluef ine
+-   * gergelker welfff fgrekj
+-   */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.final-line.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.final-line.ts
+deleted file mode 100644
+index d54f05f..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.final-line.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-          /**
+-   * clearly working comment, that is way too long to fit on a singluef ine gergelker
+-   * welfff fgrekj
+-   */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.indentation.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.indentation.expected.ts
+deleted file mode 100644
+index 125175f..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.indentation.expected.ts
++++ /dev/null
+@@ -1,6 +0,0 @@
+-/**
+- * This is a single block which does not overflow default maximum line-length
+- *    Since this line has a different indentation level it will be considered
+- *    as a separate block (which overflows!)
+- * And here is text afterwards that shouldn't be included
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.indentation.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.indentation.ts
+deleted file mode 100644
+index d0b1dbc..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.indentation.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-/**
+- * This is a single block which does not overflow default maximum line-length
+- *    Since this line has a different indentation level it will be considered as a separate block (which overflows!)
+- * And here is text afterwards that shouldn't be included
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.malformed.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.malformed.expected.ts
+deleted file mode 100644
+index 8513beb..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.malformed.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-    /**
+-     * NOTE: The CLI object should *not* call process.exit() directly. It
+-     * should overflow
+-         only return exit codes. */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.malformed.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.malformed.ts
+deleted file mode 100644
+index 84f4a6d..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.malformed.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-    /** NOTE: The CLI object should *not* call process.exit() directly. It should overflow
+-         only return exit codes. */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.multiple-lines.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.multiple-lines.expected.ts
+deleted file mode 100644
+index 188609c..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.multiple-lines.expected.ts
++++ /dev/null
+@@ -1,6 +0,0 @@
+-/**
+- * unwraps the next page descriptor to ensure that a chapter descriptor is
+- * going to be returned (if a chapter group was given, then find the first
+- * available chapter inside it or continue to the next sibling of that chapter
+- * group).
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.multiple-lines.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.multiple-lines.ts
+deleted file mode 100644
+index b4d9be0..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.multiple-lines.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-/**
+- * unwraps the next page descriptor to ensure that a chapter descriptor is going to
+- * be returned (if a chapter group was given, then find the first available chapter
+- * inside it or continue to the next sibling of that chapter group).
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.single-line.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.single-line.expected.ts
+deleted file mode 100644
+index bf61dbe..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.single-line.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-/**
+- * In case a multi-line comment is on a single line and it violates the
+- * configured max-length, then it will be split into multiple lines.
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.single-line.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.single-line.ts
+deleted file mode 100644
+index 6413982..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/invalid.single-line.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-/** In case a multi-line comment is on a single line and it violates the configured max-length, then it will be split into multiple lines. */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.code-within.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.code-within.expected.ts
+deleted file mode 100644
+index d65b76d..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.code-within.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-/**
+- * const myVariableWhichDefinitelyOverflows =
+- * window.getComputedStyle(document.body).accentColor;
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.code-within.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.code-within.ts
+deleted file mode 100644
+index fef43ff..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.code-within.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-/**
+- * const myVariableWhichDefinitelyOverflows = window.getComputedStyle(document.body).accentColor;
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.compact.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.compact.expected.ts
+deleted file mode 100644
+index 76b4cd8..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.compact.expected.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-/**
+- * here are two consequtive lines that does not overflow.
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.compact.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.compact.ts
+deleted file mode 100644
+index 32837d4..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.compact.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-/**
+- * here are two consequtive lines
+- * that does not overflow.
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.logical-wrap.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.logical-wrap.expected.ts
+deleted file mode 100644
+index 9c2aaf0..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.logical-wrap.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly.
+- * It should only return exit codes.
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.logical-wrap.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.logical-wrap.ts
+deleted file mode 100644
+index 8fd8724..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.logical-wrap.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes.
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.max-length20.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.max-length20.expected.ts
+deleted file mode 100644
+index 666cdad..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.max-length20.expected.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-/**
+- * here is a
+- * comment that
+- * exceeds 20
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.max-length20.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.max-length20.ts
+deleted file mode 100644
+index dfac31f..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.max-length20.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-/** here is a comment that exceeds 20 */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.no-urls.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.no-urls.expected.ts
+deleted file mode 100644
+index 0977c82..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.no-urls.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-/**
+- * here is a lot of text, including a very long url
+- * https://google.com/some/nested/path
+- */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.no-urls.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.no-urls.ts
+deleted file mode 100644
+index 18e502a..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/option.no-urls.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-/** here is a lot of text, including a very long url https://google.com/some/nested/path */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.backticks.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.backticks.ts
+deleted file mode 100644
+index 5ba9d67..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.backticks.ts
++++ /dev/null
+@@ -1,6 +0,0 @@
+-/**
+- * @example
+- * ```ts
+- * Everything within backticks will not be automatically formatted. They essientially acts as an escape-hatch for the automatic fix.
+- * ```
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.basic.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.basic.ts
+deleted file mode 100644
+index ac438fc..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.basic.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly.
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.comment-within-comment.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.comment-within-comment.ts
+deleted file mode 100644
+index c49267e..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.comment-within-comment.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-/** Here is my comment which // includes a very very long, overflowing comment within itself. */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.exactly-80.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.exactly-80.ts
+deleted file mode 100644
+index d31acaa..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.exactly-80.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. erglkeg elrgg
+- */
+-/** NOTE: The CLI object should *not* call process.exit() directly. erglkeg e */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.jsdoc-compact.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.jsdoc-compact.ts
+deleted file mode 100644
+index 9c92212..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.jsdoc-compact.ts
++++ /dev/null
+@@ -1,9 +0,0 @@
+-/**
+- * @custom This will be preserved
+- * @custom as will this
+- * ```
+- * what about this which definitely will overflow and could potentially be compated
+- * without
+- * any other issues than backticks?
+- * ```
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.jsdoc.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.jsdoc.ts
+deleted file mode 100644
+index 7feffe1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.jsdoc.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-/**
+- * @example Here is my JSDoc-comment which will not be automatically fixable in order to avoid altering semantics.
+- */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.oneline-jsdoc.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.oneline-jsdoc.ts
+deleted file mode 100644
+index 6fbac0a..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.oneline-jsdoc.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-/** One line description */
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.semantic.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.semantic.ts
+deleted file mode 100644
+index 75972d9..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/tests/valid.semantic.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-/* stylelint-disable some-css-plugin/some-css-rule, more-rules,that-will,trigger,overflow... */
+-/* tslint:disable comment-length/limit-single-line-comments, comment-length/limit-multi-line-comments, ... */
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/typings.block.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/typings.block.ts
+deleted file mode 100644
+index 0cf8f23..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/typings.block.ts
++++ /dev/null
+@@ -1,35 +0,0 @@
+-/**
+- * defines a singular logical block within a comment.
+- */
+-export type MultilineBlock = {
+-  /**
+-   * includes the merged value of all comment lines within the block
+-   */
+-  value: string;
+-
+-  /**
+-   * includes all textual content of all lines of this logical block
+-   */
+-  lines: string[];
+-
+-  /**
+-   * specifies, for each line, how much whitespace there is to the left of the
+-   * comment, i.e. its offset to the left.
+-   */
+-  lineOffsets: Array<{
+-    string: string;
+-    size: number;
+-  }>;
+-
+-  /**
+-   * specifies the index that the first line of this block has within the
+-   * entire comment that it is a part of.
+-   */
+-  startIndex: number;
+-
+-  /**
+-   * specifies the index that the last line of this block has within the entire
+-   * comment that it is a part of.
+-   */
+-  endIndex: number;
+-};
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.boilerplate-size.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.boilerplate-size.ts
+deleted file mode 100644
+index b884b7b..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.boilerplate-size.ts
++++ /dev/null
+@@ -1,9 +0,0 @@
+-export const SINGLE_LINE_BOILERPLATE_SIZE = 5; // i.e. '/**'.length + '*/'.length
+-export const MULTILINE_BOILERPLATE_SIZE = 2; // i.e. '/*'.length OR '*/'.length OR ' *'.length
+-export const FIRST_LINE_BOILERPLATE_SIZE = 3; // i.e. '/**'.length
+-
+-export function getBoilerPlateSize(commentLines: string[]): number {
+-  return commentLines.length === 1
+-    ? SINGLE_LINE_BOILERPLATE_SIZE
+-    : MULTILINE_BOILERPLATE_SIZE;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.can-block-be-compacted.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.can-block-be-compacted.ts
+deleted file mode 100644
+index a3eb955..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.can-block-be-compacted.ts
++++ /dev/null
+@@ -1,14 +0,0 @@
+-import { Context } from "../../typings.context";
+-
+-import { MultilineBlock } from "./typings.block";
+-import { formatBlock } from "./util.format-block";
+-
+-export function canBlockBeCompated(block: MultilineBlock, context: Context) {
+-  if (!block.value.trim()) {
+-    return false;
+-  }
+-
+-  const formattedBlock = formatBlock(block, context).trim();
+-
+-  return formattedBlock !== context.comment.value.trim();
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.capture-next-block.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.capture-next-block.ts
+deleted file mode 100644
+index 6de3ce0..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.capture-next-block.ts
++++ /dev/null
+@@ -1,169 +0,0 @@
+-import { Context } from "../../typings.context";
+-import { isLineOverflowing } from "../../utils/is-line-overflowing";
+-
+-import { MultilineBlock } from "./typings.block";
+-
+-/**
+- * captures the next logical group/block in the provided multi-line comment
+- * content, based on a set of rules.
+- *
+- * 1) Everything within a set of back-ticks (``) is ignored, as this is used
+- * to explicitly declare that the content should not be auto-fixed.
+- *
+- * 2) Lines that are not on the same indentation-level will not be recognized
+- * as part of the same block.
+- *
+- * 3) Lines separated by a new-line will not be considered as part of the same
+- * block.
+- *
+- * 4) Lines will only be grouped in case the current line of the block to be
+- * constructed actually is overflowing. This avoids issues where auto-fixing
+- * 'sucks' a line up even though the previous line should have been considered
+- * a logical end to a block.
+- */
+-export function captureNextBlock(
+-  ignoreFollowingLines: boolean,
+-  initialStartIndex: number,
+-  context: Context,
+-): [Omit<MultilineBlock, "value">, boolean] {
+-  let ignoreLines = ignoreFollowingLines;
+-  let startIndex = initialStartIndex;
+-
+-  // the provided startIndex may not necessarily indicate the startIndex of the
+-  // next logical block. (it may e.g. just point to a blank line)
+-  // as such we need to determine the actual start of the next block.
+-  for (let i = initialStartIndex; i < context.comment.lines.length; i++) {
+-    const line = context.comment.lines[i];
+-
+-    // ensure that lines within backticks is skipped (and that the line itself
+-    // is ignored as it acts as a marker).
+-    if (
+-      line?.trimStart().startsWith("` ") ||
+-      line?.trimStart().startsWith("``")
+-    ) {
+-      ignoreLines = !ignoreLines;
+-      continue;
+-    }
+-
+-    startIndex = i;
+-
+-    if (line && line.trim() !== "" && !ignoreLines) {
+-      break;
+-    }
+-  }
+-
+-  const blockLines: string[] = context.comment.lines.slice(
+-    startIndex,
+-    startIndex + 1,
+-  );
+-
+-  // In case we could not resolve the start of a new block, then we cannot
+-  // continue...
+-  if (blockLines.length === 0) {
+-    return [
+-      {
+-        lines: blockLines,
+-        startIndex,
+-        endIndex: startIndex,
+-        lineOffsets: [],
+-      },
+-      ignoreLines,
+-    ];
+-  }
+-
+-  // ... else we can begin analysing the following lines to determine if they
+-  // are to be added to the current group
+-  for (let i = startIndex; i < context.comment.lines.length; i++) {
+-    const currLine = context.comment.lines[i];
+-    const nextLine = context.comment.lines[i + 1];
+-
+-    if (!currLine) {
+-      break;
+-    }
+-
+-    const currLineOffset =
+-      currLine
+-        .match(/^( |\t)*/)?.[0]
+-        ?.split("")
+-        .reduce(
+-          (acc, curr) => acc + (curr === "\t" ? context.tabSize : 1),
+-          0,
+-        ) ?? 0;
+-
+-    const nextLineOffset =
+-      nextLine
+-        ?.match(/^( |\t)*/)?.[0]
+-        ?.split("")
+-        .reduce(
+-          (acc, curr) => acc + (curr === "\t" ? context.tabSize : 1),
+-          0,
+-        ) ?? 0;
+-
+-    if (
+-      !nextLine ||
+-      nextLine.trim() === "" ||
+-      currLineOffset !== nextLineOffset ||
+-      (context.mode === "overflow-only" &&
+-        !isLineOverflowing(
+-          `${currLine} ${nextLine.trimStart().split(" ")[0] ?? ""}`.trimEnd(),
+-          context,
+-        ))
+-    ) {
+-      return [
+-        {
+-          lines: blockLines,
+-          startIndex,
+-          endIndex: i,
+-          lineOffsets: blockLines.map((it, lineIndex) => {
+-            const whitespaceString = context.comment.value
+-              .split("\n")
+-              [startIndex + lineIndex]?.includes("*")
+-              ? it.match(/^( |\t)*/)?.[0] ?? ""
+-              : " ";
+-
+-            return {
+-              string: whitespaceString,
+-              size:
+-                whitespaceString
+-                  .split("")
+-                  .reduce(
+-                    (acc, curr) => acc + (curr === "\t" ? context.tabSize : 1),
+-                    0,
+-                  ) ?? 0,
+-            };
+-          }),
+-        },
+-        ignoreLines,
+-      ];
+-    }
+-
+-    blockLines.push(nextLine);
+-  }
+-
+-  return [
+-    {
+-      lines: blockLines,
+-      startIndex,
+-      endIndex: context.comment.lines.length,
+-      lineOffsets: blockLines.map((it, lineIndex) => {
+-        const whitespaceString = context.comment.value
+-          .split("\n")
+-          [startIndex + lineIndex]?.includes("*")
+-          ? it.match(/^( |\t)*/)?.[0] ?? ""
+-          : " ";
+-
+-        return {
+-          string: whitespaceString,
+-          size:
+-            whitespaceString
+-              .split("")
+-              .reduce(
+-                (acc, curr) => acc + (curr === "\t" ? context.tabSize : 1),
+-                0,
+-              ) ?? 0,
+-        };
+-      }),
+-    },
+-    ignoreLines,
+-  ];
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.extract-blocks.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.extract-blocks.ts
+deleted file mode 100644
+index d9c34a0..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.extract-blocks.ts
++++ /dev/null
+@@ -1,36 +0,0 @@
+-import { Context } from "../../typings.context";
+-
+-import { MultilineBlock } from "./typings.block";
+-import { captureNextBlock } from "./util.capture-next-block";
+-import { mergeLines } from "./util.merge-lines";
+-
+-export function extractBlocksFromMultilineComment(context: Context) {
+-  const blocks = [] as MultilineBlock[];
+-
+-  let ignoreFollowingLines = false;
+-
+-  // Processing multi-line comments becomes a tad more difficult than simply
+-  // parsing single-line comments since a single comment may contain
+-  // multiple logical comment blocks which should be handled individually.
+-  //
+-  // Thus our first step is to take a multi-line comment and convert it into
+-  // logical blocks
+-  for (let i = 0; i < context.comment.lines.length; i++) {
+-    if (i <= (blocks[blocks.length - 1]?.endIndex ?? -1)) {
+-      continue;
+-    }
+-
+-    const [block, ignoreLines] = captureNextBlock(
+-      ignoreFollowingLines,
+-      i,
+-      context,
+-    );
+-    blocks.push({
+-      ...block,
+-      value: block.lines.reduce((acc, curr) => mergeLines(acc, curr)),
+-    });
+-    ignoreFollowingLines = ignoreLines;
+-  }
+-
+-  return blocks;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.format-block.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.format-block.ts
+deleted file mode 100644
+index a5f734a..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.format-block.ts
++++ /dev/null
+@@ -1,74 +0,0 @@
+-import { Context } from "../../typings.context";
+-import { isAnotherWrapPointComing } from "../../utils/is-another-wrap-point-coming";
+-import { isPunctuation } from "../../utils/is-punctuation";
+-
+-import { MultilineBlock } from "./typings.block";
+-import { MULTILINE_BOILERPLATE_SIZE } from "./util.boilerplate-size";
+-
+-/**
+- * takes a fixable block and transform it into a singular string which
+- * represents the fixed format of the block.
+- */
+-export function formatBlock(fixable: MultilineBlock, context: Context): string {
+-  const lineStartSize =
+-    context.whitespace.size +
+-    MULTILINE_BOILERPLATE_SIZE +
+-    (fixable.lineOffsets[0]?.size ?? 0);
+-  const words = fixable.value.trim().split(" ");
+-
+-  const newValue = words.reduce(
+-    (acc, curr, index) => {
+-      const lengthIfAdded = acc.currentLineLength + curr.length + 1; // + 1 to act as a final space, i.e. " "
+-
+-      // We can safely split to a new line in case we are reaching and
+-      // overflowing line AND if there is at least one word on the current line.
+-      const splitToNewline =
+-        lengthIfAdded > context.maxLength &&
+-        acc.currentLineLength !== lineStartSize;
+-
+-      const previousWord = words[index - 1];
+-
+-      const splitEarly =
+-        context.logicalWrap &&
+-        acc.currentLineLength >= context.maxLength / 2 &&
+-        previousWord &&
+-        previousWord.at(-1) &&
+-        isPunctuation(previousWord.at(-1)) &&
+-        previousWord.length > 1 &&
+-        !isAnotherWrapPointComing(
+-          acc.currentLineLength,
+-          context.maxLength,
+-          words.slice(index),
+-        );
+-
+-      if (splitToNewline || splitEarly) {
+-        const nextLine = `${context.whitespace.string} *${
+-          fixable.lineOffsets[
+-            Math.min(acc.currentLineIndex + 1, fixable.lineOffsets.length - 1)
+-          ]?.string ?? ""
+-        }${curr} `;
+-
+-        return {
+-          value: `${acc.value.trimEnd()}\n${nextLine}`,
+-          currentLineLength: nextLine.length,
+-          currentLineIndex: acc.currentLineIndex + 1,
+-        };
+-      } else {
+-        return {
+-          value: `${acc.value}${curr} `,
+-          currentLineLength: lengthIfAdded,
+-          currentLineIndex: acc.currentLineIndex,
+-        };
+-      }
+-    },
+-    {
+-      value: `${context.whitespace.string} *${
+-        fixable.lineOffsets[0]?.string ?? ""
+-      }`,
+-      currentLineLength: lineStartSize,
+-      currentLineIndex: 0,
+-    },
+-  );
+-
+-  return newValue.value.trimEnd();
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.merge-lines.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.merge-lines.ts
+deleted file mode 100644
+index 437be70..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-multi-line-comments/util.merge-lines.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-export function mergeLines(a: string, b: string, separator = " "): string {
+-  return `${a.trim()}${separator}${b.trim()}`;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/const.boilerplate-size.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/const.boilerplate-size.ts
+deleted file mode 100644
+index 8e85dc6..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/const.boilerplate-size.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-export const SINGLE_LINE_COMMENT_BOILERPLATE_SIZE = 2; // i.e. '//'.length
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/docs.md b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/docs.md
+deleted file mode 100644
+index 7194a1d..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/docs.md
++++ /dev/null
+@@ -1,116 +0,0 @@
+-
+-# `comment-length/limit-single-line-comments`
+-
+-Locates single-line commments, i.e. `// comment`, and ensures that each line never exceeds the configured length.
+-
+-If a line violates this rule, the auto-fixer will attempt to combine logical groups of single-line comments and reformat those to ensure that each line is below the configured max length.
+-
+-```ts
+-// this is one logical comment block. It will be automatically split into multiple lines if fixed. Especially if the content is very very very very very very long.
+-// This is the second line of the block.
+-// This is considered as a new block since the line above does not overflow.
+-
+-// This line is also considered as a singular block.
+-```
+-
+-Which will be transformed into:
+-
+-```ts
+-// this is one logical comment block. It will be automatically split into
+-// multiple lines if fixed. Especially if the content is very very very very
+-// very very long. This is the second line of the block.
+-// This is considered as a new block since the line above does not overflow.
+-
+-// This line is also considered as a singular block.
+-```
+-
+-## Options
+-
+-```jsonc
+-{
+-  "comment-length/limit-single-line-comments": [
+-    "warn",
+-    {
+-      "mode": "overflow-only" | "compact-on-overflow" | "compact",
+-      "maxLength": 80,
+-      "logicalWrap": true,
+-      "ignoreUrls": true,
+-      "ignoreCommentsWithCode": true,
+-      "tabSize": 2
+-    }
+-  ]
+-}
+-```
+-
+-## Examples
+-
+-### Basic
+-
+-```ts
+-// this is one logical comment block. It will be automatically split into multiple lines if fixed. Especially if the content is very very very very very very long.
+-```
+-
+-Will be fixed into:
+-
+-```ts
+-// this is one logical comment block. It will be automatically split into
+-// multiple lines if fixed. Especially if the content is very very very very
+-// very very long.
+-```
+-
+-### Indentation
+-
+-When fixing this comment-block, then the leading whitespace on the following line will currently be discarded. This may change in the future.
+-
+-As an example:
+-
+-```ts
+-// When fixing this comment-block, then the leading whitespace on the following line will be discarded.
+-//    white-space will be discarded when fixing.
+-```
+-
+-Will be fixed into:
+-
+-```ts
+-// When fixing this comment-block, then the leading whitespace on the following
+-// line will be discarded. white-space will be discarded when fixing.
+-```
+-
+-### Must not be a comment with special semantics
+-
+-The comments below will NOT be automatically fixable (as this will break functionality).
+-
+-```ts
+-// eslint-disable-next-line comment-length/limit-single-line-comments, comment-length/limit-multi-line-comments
+-// styleline-disable-next-line some-css-plugin/some-css-rule, ...
+-// tslint:disable ...
+-```
+-
+-### Must be on own line
+-
+-The comment below will NOT be automatically fixable (as it is not on its own line).
+-This has been done as there is rarely much space available when a comment shares a line with actual code.
+-
+-```ts
+-const myVariable = Math.max(0, Math.min(1, window.someValue)); // clamps the external value between 0 and 1.
+-```
+-
+-### Includes a comment within the comment
+-
+-The comment below will NOT be automatically fixable as it includes a comment within itself.
+-
+-The rationale behind this decision is that developers at times will have to out-comment snippets of code when debugging. When this happens comments may also be commented out (perhaps accidentally). In this case we would like to preserve the structure of the original comment, such that when it is commented back in it follows the original layout.
+-
+-```ts
+-/** Here is my comment which // includes a very very long comment within itself. */
+-```
+-
+-### Includes a code snippet
+-
+-The comment below will NOT be automatically fixable as it includes a comment within itself.
+-
+-The rationaly is essentially the same as above. In particular we wish to avoid breaking lines when code is out-commented during debugging.
+-
+-```ts
+-// const myVariableWhichDefinitelyOverflows = window.getComputedStyle(document.body).accentColor;
+-```
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/fix.overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/fix.overflow.ts
+deleted file mode 100644
+index ebb38b1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/fix.overflow.ts
++++ /dev/null
+@@ -1,15 +0,0 @@
+-import { TSESLint, TSESTree } from "@typescript-eslint/utils";
+-
+-import { Context } from "../../typings.context";
+-
+-import { formatBlock } from "./util.format-block";
+-
+-export function fixOverflow(
+-  fixer: TSESLint.RuleFixer,
+-  fixableComment: TSESTree.LineComment,
+-  context: Context,
+-) {
+-  const newValue = formatBlock(fixableComment, context);
+-
+-  return fixer.replaceTextRange(context.comment.range, newValue);
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/root.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/root.ts
+deleted file mode 100644
+index 480575a..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/root.ts
++++ /dev/null
+@@ -1,127 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-import { RuleContext } from "@typescript-eslint/utils/ts-eslint";
+-
+-import { MessageIds } from "../../const.message-ids";
+-import { Context } from "../../typings.context";
+-import { Options } from "../../typings.options";
+-import { isCodeInComment } from "../../utils/is-code-in-comment";
+-import { isCommentInComment } from "../../utils/is-comment-in-comment";
+-import { isLineOverflowing } from "../../utils/is-line-overflowing";
+-import { isCommentOnOwnLine } from "../../utils/is-on-own-line";
+-import { isSemanticComment } from "../../utils/is-semantic-comment";
+-
+-import { SINGLE_LINE_COMMENT_BOILERPLATE_SIZE } from "./const.boilerplate-size";
+-import { fixOverflow } from "./fix.overflow";
+-import { canBlockBeCompated } from "./util.can-block-be-compacted";
+-import { captureNearbyComments } from "./util.capture-nearby-comments";
+-import { captureRelevantCommentsIntoBlock } from "./util.capture-relevant-comments";
+-
+-export function limitSingleLineComments(
+-  ruleContext: RuleContext<string, unknown[]>,
+-  options: Options,
+-  comments: TSESTree.LineComment[],
+-) {
+-  const sourceCode = ruleContext.getSourceCode();
+-  const lines = sourceCode.getLines();
+-
+-  for (let i = 0; i < comments.length; i++) {
+-    const currentCommentLine = comments[i];
+-
+-    if (
+-      !currentCommentLine?.range ||
+-      !currentCommentLine.value ||
+-      !isCommentOnOwnLine(sourceCode, currentCommentLine) ||
+-      isSemanticComment(currentCommentLine)
+-    ) {
+-      continue;
+-    }
+-
+-    const line = lines[currentCommentLine.loc.start.line - 1];
+-    const whitespaceString = line?.split("//")[0] ?? "";
+-
+-    let context = {
+-      ...options,
+-      whitespace: {
+-        string: whitespaceString,
+-        size: whitespaceString
+-          .split("")
+-          .reduce(
+-            (acc, curr) => acc + (curr === "\t" ? options.tabSize : 1),
+-            0,
+-          ),
+-      },
+-      boilerplateSize: SINGLE_LINE_COMMENT_BOILERPLATE_SIZE,
+-      comment: {
+-        range: currentCommentLine.range,
+-        lines: [currentCommentLine.value],
+-        value: currentCommentLine.value,
+-      },
+-    } satisfies Context;
+-
+-    const currentBlock = captureRelevantCommentsIntoBlock(
+-      sourceCode,
+-      comments,
+-      i,
+-      context,
+-    );
+-    const fixableComment = currentBlock.mergedComment;
+-
+-    // ensure that we only visit a captured block once
+-    i += currentBlock.endIndex - currentBlock.startIndex;
+-
+-    const nearbyComments = captureNearbyComments(comments, i);
+-    const wrappedByBackticks =
+-      (nearbyComments?.value.trimStart().startsWith("` ") ||
+-        nearbyComments?.value.trimStart().startsWith("``")) &&
+-      nearbyComments?.value.trimEnd().endsWith("`");
+-
+-    if (
+-      !fixableComment ||
+-      wrappedByBackticks ||
+-      isCommentInComment(fixableComment.value) ||
+-      isCodeInComment(nearbyComments?.value, ruleContext.parserPath, context)
+-    ) {
+-      continue;
+-    }
+-
+-    // Update our context to reflect that we may have merged multiple comment
+-    // lines into a singular block.
+-    context = {
+-      ...context,
+-      comment: {
+-        range: fixableComment.range,
+-        lines: [fixableComment.value],
+-        value: fixableComment.value,
+-      },
+-    };
+-
+-    // In case any lines in our current block overflows, then we need to warn
+-    // that overflow has been detected
+-    if (
+-      comments
+-        .slice(currentBlock.startIndex, currentBlock.endIndex + 1)
+-        .some((line) => isLineOverflowing(line.value, context))
+-    ) {
+-      ruleContext.report({
+-        loc: fixableComment.loc,
+-        messageId: MessageIds.EXCEEDS_MAX_LENGTH,
+-        data: {
+-          maxLength: context.maxLength,
+-        },
+-        fix: (fixer) => fixOverflow(fixer, fixableComment, context),
+-      });
+-    } else if (
+-      context.mode === "compact" &&
+-      canBlockBeCompated(comments, currentBlock, context)
+-    ) {
+-      ruleContext.report({
+-        loc: fixableComment.loc,
+-        messageId: MessageIds.CAN_COMPACT,
+-        data: {
+-          maxLength: context.maxLength,
+-        },
+-        fix: (fixer) => fixOverflow(fixer, fixableComment, context),
+-      });
+-    }
+-  }
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/rule.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/rule.ts
+deleted file mode 100644
+index 3c3a527..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/rule.ts
++++ /dev/null
+@@ -1,39 +0,0 @@
+-import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+-
+-import { MessageIds, reportMessages } from "../../const.message-ids";
+-import {
+-  RuleOptions,
+-  defaultOptions,
+-  optionsSchema,
+-} from "../../typings.options";
+-import { resolveDocsRoute } from "../../utils/resolve-docs-route";
+-
+-import { limitSingleLineComments } from "./root";
+-
+-const createRule = ESLintUtils.RuleCreator(resolveDocsRoute);
+-
+-export const limitSingleLineCommentsRule = createRule<RuleOptions, MessageIds>({
+-  name: "limit-single-line-comments",
+-  defaultOptions,
+-  meta: {
+-    type: "layout",
+-    fixable: "whitespace",
+-    messages: reportMessages,
+-    docs: {
+-      description:
+-        "Reflows single-line comments to ensure that blocks never exceed the configured length",
+-      recommended: "stylistic",
+-    },
+-    schema: optionsSchema,
+-  },
+-  create: (ruleContext, [options]) => {
+-    const sourceCode = ruleContext.getSourceCode();
+-    const comments = sourceCode
+-      .getAllComments()
+-      .filter((it): it is TSESTree.LineComment => it.type === "Line");
+-
+-    limitSingleLineComments(ruleContext, options, comments);
+-
+-    return {};
+-  },
+-});
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/_tests.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/_tests.ts
+deleted file mode 100644
+index 0d340b1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/_tests.ts
++++ /dev/null
+@@ -1,123 +0,0 @@
+-import path from "path";
+-
+-import { getCode } from "../../../utils/testing.get-code";
+-
+-import {  limitSingleLineCommentsRule } from "../rule";
+-import { defaultOptions } from "../../../typings.options";
+-import { MessageIds } from "../../../const.message-ids";
+-import { RuleTester } from "@typescript-eslint/utils/ts-eslint";
+-
+-const ruleTester = new RuleTester({
+-  parser: require("@typescript-eslint/parser"),
+-  parserOptions: {
+-    project: "./tsconfig.test.json",
+-    tsconfigRootDir: path.resolve(__dirname, "..", "..", "..", ".."),
+-    ecmaFeatures: {
+-      jsx: true,
+-    },
+-  },
+-  env: {
+-    browser: true,
+-    es2023: true,
+-    node: true,
+-  },
+-});
+-
+-ruleTester.run("limit-single-line-comments", limitSingleLineCommentsRule, {
+-  valid: [
+-    getCode(__dirname, "valid.basic", defaultOptions),
+-    getCode(__dirname, "valid.backticks", defaultOptions),
+-    getCode(__dirname, "valid.semantic", defaultOptions),
+-    getCode(__dirname, "valid.same-line", defaultOptions),
+-    getCode(__dirname, "valid.exactly-80", defaultOptions),
+-    getCode(__dirname, "valid.comment-within-comment", defaultOptions),
+-    getCode(__dirname, "option.no-compact", [
+-      {
+-        ...defaultOptions[0],
+-        mode: "compact",
+-      },
+-    ] as const),
+-    getCode(__dirname, "option.code-within", [
+-      {
+-        ...defaultOptions[0],
+-        ignoreCommentsWithCode: true,
+-      },
+-    ] as const),
+-    getCode(__dirname, "option.no-urls", defaultOptions),
+-    getCode(__dirname, "option.compact", [
+-      {
+-        ...defaultOptions[0],
+-        mode: "compact-on-overflow",
+-      },
+-    ] as const),
+-  ],
+-  invalid: [
+-    getCode(
+-      __dirname,
+-      "invalid.basic-overflow",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "invalid.indentation",
+-      defaultOptions,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.max-length20",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          maxLength: 20,
+-        },
+-      ] as const,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.code-within",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          ignoreCommentsWithCode: false,
+-        },
+-      ] as const,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.no-urls",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          ignoreUrls: false,
+-        },
+-      ] as const,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.compact",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          mode: "compact",
+-        },
+-      ] as const,
+-      MessageIds.CAN_COMPACT
+-    ),
+-    getCode(
+-      __dirname,
+-      "option.logical-wrap",
+-      [
+-        {
+-          ...defaultOptions[0],
+-          logicalWrap: true,
+-        },
+-      ] as const,
+-      MessageIds.EXCEEDS_MAX_LENGTH
+-    ),
+-  ],
+-});
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.basic-overflow.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.basic-overflow.expected.ts
+deleted file mode 100644
+index a6f9339..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.basic-overflow.expected.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// this is one logical comment block with two sentences. It will be
+-// automatically split into multiple lines if fixed.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.basic-overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.basic-overflow.ts
+deleted file mode 100644
+index 71aa638..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.basic-overflow.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// this is one logical comment block with two sentences. It will be automatically split into multiple lines if fixed.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.indentation.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.indentation.expected.ts
+deleted file mode 100644
+index 94c8a65..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.indentation.expected.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// When fixing this comment-block, then the leading whitespace on the following
+-// line will be discarded. white-space will be discarded when fixing.
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.indentation.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.indentation.ts
+deleted file mode 100644
+index 7f151f1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/invalid.indentation.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// When fixing this comment-block, then the leading whitespace on the following line will be discarded.
+-//    white-space will be discarded when fixing.
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.code-within.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.code-within.expected.ts
+deleted file mode 100644
+index 2c0e8e2..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.code-within.expected.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// const myVariableWhichDefinitelyOverflows =
+-// window.getComputedStyle(document.body).accentColor;
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.code-within.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.code-within.ts
+deleted file mode 100644
+index 475b59d..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.code-within.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// const myVariableWhichDefinitelyOverflows = window.getComputedStyle(document.body).accentColor;
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.compact.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.compact.expected.ts
+deleted file mode 100644
+index 02101f1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.compact.expected.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// here are two consequtive lines that does not overflow.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.compact.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.compact.ts
+deleted file mode 100644
+index 60811a0..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.compact.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// here are two consequtive lines
+-// that does not overflow.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.logical-wrap.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.logical-wrap.expected.ts
+deleted file mode 100644
+index 8412a2b..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.logical-wrap.expected.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// this is one logical comment block with two sentences.
+-// It will be automatically split into multiple lines if fixed.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.logical-wrap.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.logical-wrap.ts
+deleted file mode 100644
+index 71aa638..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.logical-wrap.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// this is one logical comment block with two sentences. It will be automatically split into multiple lines if fixed.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.max-length20.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.max-length20.expected.ts
+deleted file mode 100644
+index 8133bdf..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.max-length20.expected.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-// here is a
+-// comment that
+-// exceeds 20
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.max-length20.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.max-length20.ts
+deleted file mode 100644
+index d47780c..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.max-length20.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// here is a comment that exceeds 20
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-compact.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-compact.expected.ts
+deleted file mode 100644
+index 02101f1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-compact.expected.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// here are two consequtive lines that does not overflow.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-compact.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-compact.ts
+deleted file mode 100644
+index 00423ae..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-compact.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// here are two consequtive lines, that cannot be compacted in any way at all,
+-// that does not overflow.
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-urls.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-urls.expected.ts
+deleted file mode 100644
+index 3c0199d..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-urls.expected.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// here is a lot of text, including a very long url
+-// https://google.com/some/nested/path
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-urls.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-urls.ts
+deleted file mode 100644
+index 269cb50..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/option.no-urls.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// here is a lot of text, including a very long url https://google.com/some/nested/path
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.backticks.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.backticks.ts
+deleted file mode 100644
+index 14a94a5..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.backticks.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-// ```Everything within backticks will not be automatically formatted. They essientially acts as an escape-hatch for the automatic fix.```
+-
+-// ```ts
+-// Everything within backticks will not be automatically formatted. They essientially acts as an escape-hatch for the automatic fix.
+-// ```
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.basic.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.basic.ts
+deleted file mode 100644
+index 468a81e..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.basic.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-// this is one logical comment block. It will be automatically split into
+-// multiple lines if fixed. Especially if the content is very very very very
+-// very very long.
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.comment-within-comment.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.comment-within-comment.ts
+deleted file mode 100644
+index 6c286d9..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.comment-within-comment.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// Here is my comment which // includes a very very long comment within itself, I am that comment.
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.exactly-80.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.exactly-80.ts
+deleted file mode 100644
+index 0f90c85..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.exactly-80.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-// this is one logical comment block. It will be automatically split into ferger
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.same-line.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.same-line.ts
+deleted file mode 100644
+index f06a3cf..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.same-line.ts
++++ /dev/null
+@@ -1 +0,0 @@
+-const myVariable = Math.max(0, Math.min(1, Math.random() * 12345678)); // clamps the external value between 0 and 1.
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.semantic.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.semantic.ts
+deleted file mode 100644
+index e505247..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/tests/valid.semantic.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-// stylelint-disable-next-line some-css-plugin/some-css-rule, more-rules,that-will,trigger,overflow...
+-// tslint:disable comment-length/limit-single-line-comments, comment-length/limit-multi-line-comments, ...
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/typings.block.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/typings.block.ts
+deleted file mode 100644
+index febefcd..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/typings.block.ts
++++ /dev/null
+@@ -1,7 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-
+-export type CommentBlock = {
+-  mergedComment: TSESTree.LineComment | undefined;
+-  startIndex: number;
+-  endIndex: number;
+-};
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.can-block-be-compacted.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.can-block-be-compacted.ts
+deleted file mode 100644
+index a3e726e..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.can-block-be-compacted.ts
++++ /dev/null
+@@ -1,34 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-
+-import { Context } from "../../typings.context";
+-import { isURL } from "../../utils/is-url";
+-
+-import { CommentBlock } from "./typings.block";
+-
+-export function canBlockBeCompated(
+-  comments: TSESTree.LineComment[],
+-  block: CommentBlock,
+-  context: Context,
+-): boolean {
+-  for (let i = block.startIndex + 1; i <= block.endIndex; i++) {
+-    const prev = comments[i - 1];
+-    const curr = comments[i];
+-
+-    if (!prev || !curr || (context.ignoreUrls && isURL(curr?.value))) {
+-      continue;
+-    }
+-
+-    const firstWordOnCurrentLine = curr.value.trim().split(" ")[0];
+-    const lengthOfPrevLine =
+-      prev.value.length + context.boilerplateSize + context.whitespace.size + 1;
+-
+-    if (
+-      lengthOfPrevLine + 1 + (firstWordOnCurrentLine?.length ?? 0) <=
+-      context.maxLength
+-    ) {
+-      return true;
+-    }
+-  }
+-
+-  return false;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.capture-nearby-comments.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.capture-nearby-comments.ts
+deleted file mode 100644
+index e410f9f..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.capture-nearby-comments.ts
++++ /dev/null
+@@ -1,44 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-
+-import { mergeComments } from "./util.merge-comments";
+-
+-export function captureNearbyComments(
+-  comments: TSESTree.LineComment[],
+-  startIndex: number,
+-): TSESTree.LineComment | undefined {
+-  let comment = comments[startIndex];
+-
+-  if (!comment) {
+-    return;
+-  }
+-
+-  // Previous comments
+-  for (let i = startIndex - 1; i >= 0; i--) {
+-    const prevComment = comments[i];
+-
+-    if (
+-      !prevComment ||
+-      (prevComment.loc?.end.line ?? 0) + 1 !== comment.loc?.start.line
+-    ) {
+-      break;
+-    }
+-
+-    comment = mergeComments(prevComment, comment, "\n");
+-  }
+-
+-  // Following comments
+-  for (let i = startIndex + 1; i < comments.length; i++) {
+-    const nextComment = comments[i];
+-
+-    if (
+-      !nextComment ||
+-      nextComment.loc?.start.line !== (comment.loc?.end.line ?? 0) + 1
+-    ) {
+-      break;
+-    }
+-
+-    comment = mergeComments(comment, nextComment, "\n");
+-  }
+-
+-  return comment;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.capture-relevant-comments.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.capture-relevant-comments.ts
+deleted file mode 100644
+index ed344ef..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.capture-relevant-comments.ts
++++ /dev/null
+@@ -1,45 +0,0 @@
+-import { TSESLint, TSESTree } from "@typescript-eslint/utils";
+-
+-import { Context } from "../../typings.context";
+-import { isLineOverflowing } from "../../utils/is-line-overflowing";
+-import { isCommentOnOwnLine } from "../../utils/is-on-own-line";
+-import { isSemanticComment } from "../../utils/is-semantic-comment";
+-
+-import { CommentBlock } from "./typings.block";
+-import { mergeComments } from "./util.merge-comments";
+-
+-export function captureRelevantCommentsIntoBlock(
+-  sourceCode: TSESLint.SourceCode,
+-  comments: TSESTree.LineComment[],
+-  startIndex: number,
+-  context: Context,
+-): CommentBlock {
+-  let comment = comments[startIndex];
+-
+-  if (!comment) {
+-    return { mergedComment: undefined, startIndex, endIndex: startIndex };
+-  }
+-
+-  let endIndex = startIndex;
+-
+-  for (let i = startIndex + 1; i < comments.length; i++) {
+-    const nextComment = comments[i];
+-
+-    if (
+-      (context.mode === "overflow-only" &&
+-        !isLineOverflowing(comment.value, context)) ||
+-      !nextComment ||
+-      nextComment.value.trim() === "" ||
+-      nextComment.loc?.start.line !== (comment.loc?.end.line ?? 0) + 1 ||
+-      isSemanticComment(nextComment) ||
+-      !isCommentOnOwnLine(sourceCode, nextComment)
+-    ) {
+-      break;
+-    }
+-
+-    comment = mergeComments(comment, nextComment);
+-    endIndex = i;
+-  }
+-
+-  return { mergedComment: comment, startIndex, endIndex };
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.format-block.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.format-block.ts
+deleted file mode 100644
+index 2160f26..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.format-block.ts
++++ /dev/null
+@@ -1,58 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-
+-import { Context } from "../../typings.context";
+-import { isAnotherWrapPointComing } from "../../utils/is-another-wrap-point-coming";
+-import { isPunctuation } from "../../utils/is-punctuation";
+-import { isURL } from "../../utils/is-url";
+-
+-import { SINGLE_LINE_COMMENT_BOILERPLATE_SIZE } from "./const.boilerplate-size";
+-
+-export function formatBlock(
+-  block: TSESTree.LineComment,
+-  context: Context,
+-): string {
+-  const lineStartSize =
+-    context.whitespace.size + SINGLE_LINE_COMMENT_BOILERPLATE_SIZE;
+-  const words = block.value.trim().split(" ");
+-  const newValue = words.reduce(
+-    (acc, curr, index) => {
+-      const currentWordIsURL = isURL(curr);
+-      const lengthIfAdded = acc.currentLineLength + curr.length + 1;
+-
+-      // We can safely split to a new line in case we are reaching and
+-      // overflowing line AND if there is at least one word on the current line.
+-      const splitToNewline =
+-        lengthIfAdded >= context.maxLength &&
+-        acc.currentLineLength !== lineStartSize &&
+-        (!context.ignoreUrls || !currentWordIsURL);
+-
+-      const previousWord = words[index - 1];
+-
+-      const splitEarly =
+-        context.logicalWrap &&
+-        acc.currentLineLength >= context.maxLength / 2 &&
+-        previousWord &&
+-        isPunctuation(previousWord.at(-1)) &&
+-        previousWord.length > 1 &&
+-        !isAnotherWrapPointComing(
+-          acc.currentLineLength,
+-          context.maxLength,
+-          words.slice(index),
+-        );
+-
+-      if (splitToNewline || splitEarly) {
+-        return {
+-          value: `${acc.value}\n${context.whitespace.string}// ${curr}`,
+-          currentLineLength: lineStartSize + curr.length,
+-        };
+-      } else {
+-        return {
+-          value: `${acc.value} ${curr}`,
+-          currentLineLength: lengthIfAdded,
+-        };
+-      }
+-    },
+-    { value: "//", currentLineLength: lineStartSize },
+-  );
+-  return newValue.value;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.merge-comments.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.merge-comments.ts
+deleted file mode 100644
+index 6c534f1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-single-line-comments/util.merge-comments.ts
++++ /dev/null
+@@ -1,23 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-
+-import { deepCloneValue } from "../../utils/immutable-deep-merge";
+-
+-export function mergeComments(
+-  a: TSESTree.LineComment,
+-  b: TSESTree.LineComment,
+-  separator = " ",
+-): TSESTree.LineComment {
+-  const newComment = deepCloneValue(a);
+-
+-  newComment.value = `${a.value.trim()}${separator}${b.value.trim()}`;
+-
+-  if (newComment.loc && b.loc) {
+-    newComment.loc.end = b.loc.end;
+-  }
+-
+-  if (newComment.range && b.range) {
+-    newComment.range[1] = b.range[1];
+-  }
+-
+-  return newComment;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/docs.md b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/docs.md
+deleted file mode 100644
+index 1899b64..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/docs.md
++++ /dev/null
+@@ -1,50 +0,0 @@
+-
+-# `comment-length/limit-tagged-template-literal-comments`
+-
+-Locates javascript comments, i.e. `/* comment */` or `// comment` within `tagged template literals` and ensures that each line in the comment never exceeds the configured length.
+-
+-If a line violates this rule, the auto-fixer will attempt to combine logical groups of lines inside the comment and reformat those to ensure that each line is below the configured max length.
+-
+-**NB** This rule is a basic wrapper on top of the rules `comment-length/limit-single-line-comments` and `comment-length/limit-multi-line-comments` that parses comments within tagged template literals and then forwards these comments to the other rules.
+-
+-This rule is especially intended for `CSS-in-JS` wherein comments may be used. As an example consider the snippet below:
+-
+-```ts
+-const myCss = css`
+-  /** we have decided to use this color due to its unique qualities etc. Unfortunately this line is far too long, and tedious to fix manually. */
+-  color: green;
+-`;
+-```
+-
+-Normally the comment within the tagged template literal will not be automatically fixed. However, when this rule is included, then the snippet above will be transformed into the following:
+-
+-```ts
+-const myCss = css`
+-  /**
+-   * we have decided to use this color due to its unique qualities etc.
+-   * Unfortunately this line is far too long, and tedious to fix manually.
+-   */
+-  color: green;
+-`;
+-```
+-
+-## Options
+-
+-```jsonc
+-{
+-  "comment-length/limit-multi-line-comments": [
+-    "warn",
+-    {
+-      "tags": ["css"], // include names of all tags that comment detection should be performed on.
+-
+-      // the configurations below will be propagated to the other rules that this rule extends.
+-      "mode": "overflow-only" | "compact-on-overflow" | "compact",
+-      "maxLength": 80,
+-      "logicalWrap": true,
+-      "ignoreUrls": true,
+-      "ignoreCommentsWithCode": true,
+-      "tabSize": 2
+-    }
+-  ]
+-}
+-```
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/rule.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/rule.ts
+deleted file mode 100644
+index fdb8c81..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/rule.ts
++++ /dev/null
+@@ -1,174 +0,0 @@
+-import {
+-  AST_TOKEN_TYPES,
+-  TSESTree,
+-  ESLintUtils,
+-} from "@typescript-eslint/utils";
+-import { isIdentifier } from "@typescript-eslint/utils/ast-utils";
+-
+-import { MessageIds, reportMessages } from "../../const.message-ids";
+-import {
+-  RuleOptions,
+-  defaultOptions,
+-  optionsSchema,
+-} from "../../typings.options";
+-import { resolveDocsRoute } from "../../utils/resolve-docs-route";
+-import { limitMultiLineComments } from "../limit-multi-line-comments/root";
+-import { limitSingleLineComments } from "../limit-single-line-comments/root";
+-
+-const createRule = ESLintUtils.RuleCreator(resolveDocsRoute);
+-
+-export const limitTaggedTemplateLiteralCommentsRule = createRule<
+-  RuleOptions & [{ tags: string[] }],
+-  MessageIds
+->({
+-  name: "limit-tagged-template-literal-comments",
+-  defaultOptions: [{ ...defaultOptions[0], tags: ["css"] }],
+-  meta: {
+-    type: "layout",
+-    fixable: "whitespace",
+-    messages: reportMessages,
+-    docs: {
+-      description:
+-        "Reflows javascript comments within tagged template literals to ensure that blocks never exceed the configured length",
+-      recommended: "stylistic",
+-    },
+-    schema: [
+-      {
+-        ...optionsSchema,
+-        type: "object",
+-        properties: {
+-          ...optionsSchema[0].properties,
+-          tags: { type: "array", items: { type: "string" } },
+-        },
+-      },
+-    ],
+-  },
+-
+-  create: (ruleContext, [options]) => {
+-    return {
+-      TaggedTemplateExpression: (node) => {
+-        if (!isIdentifier(node.tag) || !options.tags.includes(node.tag.name)) {
+-          return;
+-        }
+-
+-        const blockComments = [] as TSESTree.BlockComment[];
+-        const lineComments = [] as TSESTree.LineComment[];
+-
+-        for (const quasi of node.quasi.quasis) {
+-          let column = quasi.loc.start.column;
+-          let line = quasi.loc.start.line;
+-          let rangeIndex = quasi.range[0];
+-
+-          let currentBlockComment: undefined | TSESTree.BlockComment;
+-          let currentLineComment: undefined | TSESTree.LineComment;
+-
+-          for (let cursor = 0; cursor < quasi.value.cooked.length; cursor++) {
+-            const currentChar = quasi.value.cooked[cursor];
+-            const nextChar = quasi.value.cooked[cursor + 1];
+-
+-            rangeIndex++;
+-
+-            if (currentChar === "/" && nextChar === "*") {
+-              currentBlockComment = {
+-                type: AST_TOKEN_TYPES.Block,
+-                value: "",
+-                loc: {
+-                  start: {
+-                    column,
+-                    line,
+-                  },
+-                  end: {
+-                    column: 0,
+-                    line: 0,
+-                  },
+-                },
+-                range: [rangeIndex, 0],
+-              };
+-
+-              // Skip the next char which is also part of the start of our
+-              // comment.
+-              cursor++;
+-              column += 2;
+-              rangeIndex++;
+-              continue;
+-            }
+-
+-            if (
+-              currentChar === "*" &&
+-              nextChar === "/" &&
+-              currentBlockComment
+-            ) {
+-              cursor++;
+-              column += 2;
+-              rangeIndex++;
+-
+-              currentBlockComment.loc.end.line = line;
+-              currentBlockComment.loc.end.column = column;
+-              currentBlockComment.range[1] = rangeIndex + 1;
+-
+-              blockComments.push(currentBlockComment);
+-              currentBlockComment = undefined;
+-
+-              continue;
+-            }
+-
+-            if (
+-              currentChar === "/" &&
+-              nextChar === "/" &&
+-              quasi.value.cooked[cursor + 2] === " "
+-            ) {
+-              currentLineComment = {
+-                type: AST_TOKEN_TYPES.Line,
+-                value: "",
+-                loc: {
+-                  start: {
+-                    column,
+-                    line,
+-                  },
+-                  end: {
+-                    column: 0,
+-                    line: 0,
+-                  },
+-                },
+-                range: [rangeIndex, 0],
+-              };
+-
+-              cursor++;
+-              column += 2;
+-              rangeIndex++;
+-              continue;
+-            }
+-
+-            if (currentBlockComment) {
+-              currentBlockComment.value += currentChar;
+-            }
+-
+-            if (currentLineComment) {
+-              currentLineComment.value += currentChar;
+-            }
+-
+-            if (currentChar === "\n") {
+-              if (currentLineComment) {
+-                currentLineComment.loc.end.line = line;
+-                currentLineComment.loc.end.column = column;
+-                currentLineComment.range[1] = rangeIndex;
+-
+-                lineComments.push(currentLineComment);
+-
+-                currentLineComment = undefined;
+-              }
+-
+-              line++;
+-              column = 0;
+-            } else {
+-              column++;
+-            }
+-          }
+-        }
+-
+-        limitSingleLineComments(ruleContext, options, lineComments);
+-        limitMultiLineComments(ruleContext, options, blockComments);
+-      },
+-    };
+-  },
+-});
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/_tests.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/_tests.ts
+deleted file mode 100644
+index 1015ffe..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/_tests.ts
++++ /dev/null
+@@ -1,67 +0,0 @@
+-import path from "path";
+-
+-import { getCode } from "../../../utils/testing.get-code";
+-
+-import { RuleOptions, defaultOptions as baseOptions } from "../../../typings.options";
+-import { MessageIds } from "../../../const.message-ids";
+-import { limitTaggedTemplateLiteralCommentsRule } from "../rule";
+-import { RuleTester } from "@typescript-eslint/utils/ts-eslint";
+-
+-const ruleTester = new RuleTester({
+-  parser: require("@typescript-eslint/parser"),
+-  parserOptions: {
+-    project: "./tsconfig.test.json",
+-    tsconfigRootDir: path.resolve(__dirname, "..", "..", "..", ".."),
+-    ecmaFeatures: {
+-      jsx: true,
+-    },
+-  },
+-  env: {
+-    browser: true,
+-    es2023: true,
+-    node: true,
+-  },
+-});
+-
+-const defaultOptions = [{ ...baseOptions[0], tags: ["css"] }] as RuleOptions & [{ tags: string[] }];
+-
+-ruleTester.run(
+-  "limit-tagged-template-literal-comments",
+-  limitTaggedTemplateLiteralCommentsRule,
+-  {
+-    valid: [],
+-    invalid: [
+-      getCode(
+-        __dirname,
+-        "invalid.basic-single-line-overflow",
+-        defaultOptions,
+-        MessageIds.EXCEEDS_MAX_LENGTH
+-      ),
+-      getCode(
+-        __dirname,
+-        "invalid.basic-multi-line-overflow",
+-        defaultOptions,
+-        MessageIds.EXCEEDS_MAX_LENGTH
+-      ),
+-      getCode(
+-        __dirname,
+-        "invalid.malformed",
+-        defaultOptions,
+-        MessageIds.EXCEEDS_MAX_LENGTH
+-      ),
+-      getCode(
+-        __dirname,
+-        "invalid.malformed-2",
+-        defaultOptions,
+-        MessageIds.EXCEEDS_MAX_LENGTH
+-      ),
+-      getCode(
+-        __dirname,
+-        "multiple-comments-with-overflow",
+-        defaultOptions,
+-        MessageIds.EXCEEDS_MAX_LENGTH,
+-        6
+-      ),
+-    ],
+-  }
+-);
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-multi-line-overflow.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-multi-line-overflow.expected.ts
+deleted file mode 100644
+index e7b9025..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-multi-line-overflow.expected.ts
++++ /dev/null
+@@ -1,6 +0,0 @@
+-css`
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes.
+- */
+-`;
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-multi-line-overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-multi-line-overflow.ts
+deleted file mode 100644
+index 190acfd..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-multi-line-overflow.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-css`
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes.
+- */
+-`;
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-single-line-overflow.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-single-line-overflow.expected.ts
+deleted file mode 100644
+index fb31480..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-single-line-overflow.expected.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-css`
+-// this is one logical comment block. It will be automatically split into
+-// multiple lines if fixed.
+-`;
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-single-line-overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-single-line-overflow.ts
+deleted file mode 100644
+index e284073..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.basic-single-line-overflow.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-css`
+-// this is one logical comment block. It will be automatically split into multiple lines if fixed.
+-`;
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed-2.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed-2.expected.ts
+deleted file mode 100644
+index 796473b..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed-2.expected.ts
++++ /dev/null
+@@ -1,7 +0,0 @@
+-const css = css`
+-  /*
+-   * translate lines -70.710% to align with the left edge of the container with
+-   * overflow (value based on the Pythagorean theorem) and rotate the direction
+-   * of the chevron by additional 90deg
+-   */
+-`;
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed-2.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed-2.ts
+deleted file mode 100644
+index aa2e329..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed-2.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-const css = css`
+-  /* translate lines -70.710% to align with the left edge of the container with overflow
+-   * (value based on the Pythagorean theorem) and rotate the direction of the
+-   * chevron by additional 90deg */
+-`;
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed.expected.ts
+deleted file mode 100644
+index 8622545..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed.expected.ts
++++ /dev/null
+@@ -1,6 +0,0 @@
+-css`
+-  /**
+-   * NOTE: The CLI object should *not* call process.exit() directly. It should
+-   * overflow
+-     only return exit codes. */
+-`;
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed.ts
+deleted file mode 100644
+index f328373..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/invalid.malformed.ts
++++ /dev/null
+@@ -1,4 +0,0 @@
+-css`
+-  /** NOTE: The CLI object should *not* call process.exit() directly. It should overflow
+-     only return exit codes. */
+-`;
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/multiple-comments-with-overflow.expected.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/multiple-comments-with-overflow.expected.ts
+deleted file mode 100644
+index d04c767..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/multiple-comments-with-overflow.expected.ts
++++ /dev/null
+@@ -1,24 +0,0 @@
+-css`
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes.
+- */
+-// this is one logical comment block. It will be automatically split into
+-// multiple lines if fixed.
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes.
+- */
+-color: ${colors.green};
+-
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes.
+- */
+-// this is one logical comment block. It will be automatically split into
+-// multiple lines if fixed.
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should
+- * only return exit codes.
+- */
+-`;
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/multiple-comments-with-overflow.ts b/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/multiple-comments-with-overflow.ts
+deleted file mode 100644
+index 038c4ca..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/rules/limit-tagged-template-literal-comments/tests/multiple-comments-with-overflow.ts
++++ /dev/null
+@@ -1,18 +0,0 @@
+-css`
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes.
+- */
+-// this is one logical comment block. It will be automatically split into multiple lines if fixed.
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes.
+- */
+-color: ${colors.green};
+-
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes.
+- */
+-// this is one logical comment block. It will be automatically split into multiple lines if fixed.
+-/**
+- * NOTE: The CLI object should *not* call process.exit() directly. It should only return exit codes.
+- */
+-`;
+\ No newline at end of file
+diff --git a/node_modules/eslint-plugin-comment-length/src/typings.context.ts b/node_modules/eslint-plugin-comment-length/src/typings.context.ts
+deleted file mode 100644
+index 43bd556..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/typings.context.ts
++++ /dev/null
+@@ -1,29 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-
+-import type { Options } from "./typings.options";
+-
+-export type Context = Options & {
+-  /**
+-   * specifies the amount and format of whitespace a particular comment has to
+-   * the left of it.
+-   */
+-  whitespace: {
+-    string: string;
+-    size: number;
+-  };
+-
+-  /**
+-   * specifies the amount if characters that a particular comment boilerplate
+-   * takes (e.g. '// '.length --> 3)
+-   */
+-  boilerplateSize: number;
+-
+-  /**
+-   * contains context related to the currently analyzed comment
+-   */
+-  comment: {
+-    value: string;
+-    lines: string[];
+-    range: TSESTree.Range;
+-  };
+-};
+diff --git a/node_modules/eslint-plugin-comment-length/src/typings.options.ts b/node_modules/eslint-plugin-comment-length/src/typings.options.ts
+deleted file mode 100644
+index 7abcbd5..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/typings.options.ts
++++ /dev/null
+@@ -1,99 +0,0 @@
+-import { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
+-
+-export type Options = {
+-  /**
+-   * specifies how the auto-fix wrapping mechanism functions.
+-   *
+-   * - "overflow-only" ensures that only overflowing lines are reflowed to new
+-   * lines,
+-   *
+-   * - whereas "compact" tries to produce as compact blocks as possible,
+-   * potentially merging multiple nearby lines even though no overflow was
+-   * occuring on the lines.
+-   *
+-   * - Finally, "compact-on-overflow" attempts to produce as compact blocks as
+-   * possible, however only when overflow within a block has been detected.
+-   *
+-   * @default overflow-only
+-   */
+-  mode: "overflow-only" | "compact-on-overflow" | "compact";
+-
+-  /**
+-   * specifies the maxmium length that a comment is allowed to take
+-   *
+-   * @default 80
+-   */
+-  maxLength: number;
+-
+-  /**
+-   * attempts to wrap at logical pauses in comments based on where punctuation
+-   * is found.
+-   *
+-   * This will often wrap the text sooner than if this was disabled,
+-   * but it potentially makes it easier to read comments.
+-   *
+-   * @default false
+-   */
+-  logicalWrap: boolean;
+-
+-  /**
+-   * if set to true, then overflow lines including comments will be ignored
+-   *
+-   * @default true
+-   */
+-  ignoreUrls: boolean;
+-
+-  /**
+-   * attempts to avoid reflowing comments that contains code as this may break
+-   * the semantic meaning of the code.
+-   *
+-   * NB: This option causes ESLint to be run on comment content in an attempt
+-   * to see if the code inside is parsable, which may have a significant
+-   * performance impact depending on the parser used.
+-   *
+-   * @default false
+-   */
+-  ignoreCommentsWithCode: boolean;
+-
+-  /**
+-   * in case you are using tabs to indent your code, then this plugin needs to
+-   * know the configured tab size, in order to properly determine when a
+-   * comment exceeds the configured max length.
+-   *
+-   * If you are using VSCode, then this option should match the
+-   * `editor.tabSize` option.
+-   *
+-   * @default 2
+-   */
+-  tabSize: number;
+-};
+-
+-export type RuleOptions = [Options];
+-
+-export const defaultOptions = [
+-  {
+-    mode: "overflow-only",
+-    maxLength: 80,
+-    ignoreUrls: true,
+-    ignoreCommentsWithCode: false,
+-    tabSize: 2,
+-    logicalWrap: false,
+-  },
+-] satisfies RuleOptions;
+-
+-export const optionsSchema = [
+-  {
+-    type: "object",
+-    properties: {
+-      mode: {
+-        type: "string",
+-        enum: ["overflow-only", "compact-on-overflow", "compact"],
+-      },
+-      maxLength: { type: "integer" },
+-      ignoreUrls: { type: "boolean" },
+-      ignoreCommentsWithCode: { type: "boolean" },
+-      tabSize: { type: "integer" },
+-      logicalWrap: { type: "boolean" },
+-    },
+-  },
+-] satisfies [JSONSchema4];
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/immutable-deep-merge.ts b/node_modules/eslint-plugin-comment-length/src/utils/immutable-deep-merge.ts
+deleted file mode 100644
+index be4cd5f..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/immutable-deep-merge.ts
++++ /dev/null
+@@ -1,34 +0,0 @@
+-export function deepCloneValue<T>(val: T): T {
+-  if (isRecord(val)) {
+-    return deepCloneObject(val);
+-  } else if (Array.isArray(val)) {
+-    return deepCloneArray(val);
+-  } else {
+-    return val;
+-  }
+-}
+-
+-export function deepCloneObject<T extends Record<string, unknown>>(a: T): T {
+-  const keys = new Set(Object.keys(a));
+-  const clone: Record<string, unknown> = {};
+-
+-  for (const key of keys) {
+-    clone[key] = deepCloneValue(a[key]);
+-  }
+-
+-  return clone as T;
+-}
+-
+-function deepCloneArray<T extends Array<unknown>>(arr: T): T {
+-  const newArr = [];
+-
+-  for (const val of arr) {
+-    newArr.push(deepCloneValue(val));
+-  }
+-
+-  return newArr as T;
+-}
+-
+-function isRecord(value: unknown): value is Record<string, unknown> {
+-  return typeof value === "object" && value != null && !Array.isArray(value);
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-another-wrap-point-coming.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-another-wrap-point-coming.ts
+deleted file mode 100644
+index 96aa063..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-another-wrap-point-coming.ts
++++ /dev/null
+@@ -1,18 +0,0 @@
+-import { isPunctuation } from "./is-punctuation";
+-
+-export function isAnotherWrapPointComing(
+-  currentLength: number,
+-  maxLength: number,
+-  wordsToCome: string[],
+-): boolean {
+-  for (const word of wordsToCome) {
+-    if (isPunctuation(word.at(-1)) && word.length > 1) {
+-      return true;
+-    }
+-    currentLength += word.length + 1;
+-    if (currentLength >= maxLength) {
+-      return false;
+-    }
+-  }
+-  return false;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-code-in-comment.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-code-in-comment.ts
+deleted file mode 100644
+index 8ca28a6..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-code-in-comment.ts
++++ /dev/null
+@@ -1,35 +0,0 @@
+-import { Linter } from "@typescript-eslint/utils/ts-eslint";
+-
+-import { Context } from "../typings.context";
+-
+-export function isCodeInComment(
+-  value: string | undefined,
+-  parserPath: string,
+-  context: Context,
+-): boolean {
+-  if (!value || !context.ignoreCommentsWithCode) {
+-    return false;
+-  }
+-
+-  const linter = new Linter();
+-
+-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+-  linter.defineParser("parser", require(parserPath) as Linter.ParserModule);
+-  const output = linter.verify(value, {
+-    parser: "parser",
+-    parserOptions: { ecmaVersion: "latest" },
+-    env: {
+-      node: true,
+-      es2023: true,
+-      browser: true,
+-    },
+-  });
+-
+-  for (const msg of output) {
+-    if (msg.message.includes("Parsing error")) {
+-      return false;
+-    }
+-  }
+-
+-  return true;
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-comment-in-comment.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-comment-in-comment.ts
+deleted file mode 100644
+index e227f66..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-comment-in-comment.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-export function isCommentInComment(value: string): boolean {
+-  return value.includes("// ") || value.includes("/*") || value.includes("*/");
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-jsdoc-like.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-jsdoc-like.ts
+deleted file mode 100644
+index 5637687..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-jsdoc-like.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-export function isJSDocLikeComment(value: string): boolean {
+-  return value.trimStart().startsWith("@");
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-line-overflowing.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-line-overflowing.ts
+deleted file mode 100644
+index e98791b..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-line-overflowing.ts
++++ /dev/null
+@@ -1,12 +0,0 @@
+-import { Context } from "../typings.context";
+-
+-import { isURL } from "./is-url";
+-
+-export function isLineOverflowing(line: string, context: Context): boolean {
+-  return (
+-    (!context.ignoreUrls || !isURL(line)) &&
+-    line.trim().split(" ").length > 1 &&
+-    line.length + context.whitespace.size + context.boilerplateSize >
+-      context.maxLength
+-  );
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-on-own-line.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-on-own-line.ts
+deleted file mode 100644
+index 9f503f5..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-on-own-line.ts
++++ /dev/null
+@@ -1,14 +0,0 @@
+-import { TSESLint, TSESTree } from "@typescript-eslint/utils";
+-
+-export function isCommentOnOwnLine(
+-  sourceCode: TSESLint.SourceCode,
+-  comment: TSESTree.BlockComment | TSESTree.LineComment,
+-): boolean {
+-  const previousToken = sourceCode.getTokenBefore(comment);
+-  const nextToken = sourceCode.getTokenAfter(comment);
+-
+-  return (
+-    previousToken?.loc.end.line !== comment.loc?.start.line &&
+-    nextToken?.loc.start.line !== comment.loc?.end.line
+-  );
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-punctuation.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-punctuation.ts
+deleted file mode 100644
+index 050f4e7..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-punctuation.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-const punctuation = [",", ".", "?", ":", "!", ";"];
+-
+-export function isPunctuation(char: string | undefined): boolean {
+-  return !!char && punctuation.includes(char);
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-semantic-comment.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-semantic-comment.ts
+deleted file mode 100644
+index 54f47c1..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-semantic-comment.ts
++++ /dev/null
+@@ -1,14 +0,0 @@
+-import { TSESTree } from "@typescript-eslint/utils";
+-
+-export function isSemanticComment(
+-  comment: TSESTree.BlockComment | TSESTree.LineComment,
+-): boolean {
+-  return (
+-    comment.value.includes("eslint-disable") ||
+-    comment.value.includes("stylelint-disable") ||
+-    comment.value.includes("tslint:disable") ||
+-    comment.value.includes("eslint-enable") ||
+-    comment.value.includes("stylelint-enable") ||
+-    comment.value.includes("tslint:enable")
+-  );
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/is-url.ts b/node_modules/eslint-plugin-comment-length/src/utils/is-url.ts
+deleted file mode 100644
+index 6f00098..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/is-url.ts
++++ /dev/null
+@@ -1,13 +0,0 @@
+-/**
+- * Copied from ESLint:
+- * https://github.com/eslint/eslint/blob/main/lib/rules/max-len.js
+- */
+-const URL_REGEXP = /[^:/?#]:\/\/[^?#]/u;
+-
+-export function isURL(str: string | undefined): boolean {
+-  if (!str) {
+-    return false;
+-  }
+-
+-  return URL_REGEXP.test(str);
+-}
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/resolve-docs-route.ts b/node_modules/eslint-plugin-comment-length/src/utils/resolve-docs-route.ts
+deleted file mode 100644
+index 369dbfb..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/resolve-docs-route.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-export const resolveDocsRoute = (rulename: string): string => {
+-  return `https://github.com/lasselupe33/eslint-plugin-comment-length/tree/master/src/rules/${rulename}/docs.md`;
+-};
+diff --git a/node_modules/eslint-plugin-comment-length/src/utils/testing.get-code.ts b/node_modules/eslint-plugin-comment-length/src/utils/testing.get-code.ts
+deleted file mode 100644
+index 7517a8b..0000000
+--- a/node_modules/eslint-plugin-comment-length/src/utils/testing.get-code.ts
++++ /dev/null
+@@ -1,61 +0,0 @@
+-import fs from "fs";
+-
+-import type {
+-  InvalidTestCase,
+-  ValidTestCase,
+-} from "@typescript-eslint/utils/ts-eslint";
+-// eslint-disable-next-line import/no-extraneous-dependencies
+-import resolve from "enhanced-resolve";
+-
+-const resolver = resolve.create.sync({
+-  extensions: [".ts", ".tsx", ".js", ".jsx"],
+-});
+-
+-export function getCode<TOpts extends readonly unknown[]>(
+-  dirname: string,
+-  name: string,
+-  options: TOpts,
+-): ValidTestCase<TOpts>;
+-export function getCode<TIds extends string, TOpts extends readonly unknown[]>(
+-  dirname: string,
+-  name: string,
+-  options: TOpts,
+-  expectedError: TIds,
+-  repeat?: number,
+-): InvalidTestCase<TIds, TOpts>;
+-export function getCode<TIds extends string, TOpts extends readonly unknown[]>(
+-  dirname: string,
+-  name: string,
+-  options: TOpts,
+-  expectedError?: TIds,
+-  repeat?: number,
+-): ValidTestCase<TOpts> | InvalidTestCase<TIds, TOpts> {
+-  const resolvedPath = resolver(dirname, `./${name}`);
+-
+-  if (!resolvedPath) {
+-    throw new Error("getCode(): Unable to resolve path");
+-  }
+-
+-  const base = {
+-    name,
+-    code: fs.readFileSync(resolvedPath, "utf-8"),
+-    filename: resolvedPath,
+-    options: options,
+-  };
+-
+-  if (!expectedError) {
+-    return base;
+-  }
+-
+-  const expectedValuePath = resolver(dirname, `./${name}.expected`);
+-
+-  if (!expectedValuePath) {
+-    throw new Error("getCode(): Unable to resolve expected value path");
+-  }
+-
+-  return {
+-    ...base,
+-    errors: new Array(repeat ?? 1).fill({ messageId: expectedError }),
+-    output: fs.readFileSync(expectedValuePath, "utf-8"),
+-  };
+-}


### PR DESCRIPTION
Prettier explicitly ignores comments. However, scrolling to read comments is getting old quick, so explicitly wrapping them.

This may interfere with ascii-schema comments, but is pretty easy to disable for that specific multi-line block.