### PR TITLE
feat(test-files): Convert test files to vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,11 @@
 		"typescript": "5.6.2",
 		"vitest": "2.0.5"
 	},
-	"workspaces": ["packages/*", "apps/*"]
+	"workspaces": [
+		"packages/*",
+		"apps/*"
+	],
+	"volta": {
+		"node": "22.9.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,7 @@
 		"typescript": "5.6.3",
 		"vitest": "2.0.5"
 	},
-	"workspaces": [
-		"packages/*",
-		"apps/*"
-	],
+	"workspaces": ["packages/*", "apps/*"],
 	"volta": {
 		"node": "22.9.0"
 	}

--- a/packages/compas-convert/src/index.ts
+++ b/packages/compas-convert/src/index.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import consola from "consola";
 import { createEmptyContext } from "./context.js";
 import type { GlobalPass, Pass } from "./pass.js";
+import { addCommonImports } from "./passes/add-common-imports.js";
 import { convertTestFiles } from "./passes/convert-test-files.js";
 import { copyRename } from "./passes/copy-rename.js";
 import { finalizePendingImports } from "./passes/finalize-pending-imports.js";
@@ -16,6 +17,7 @@ import { installDependencies } from "./passes/install-dependencies.js";
 import { runGenerators } from "./passes/run-generators.js";
 import { fixTypesOfAllFunctions } from "./passes/types-of-all-functions.js";
 import { fixTypesOfLiveBindings } from "./passes/types-of-live-bindings.js";
+import { typescriptDiagnostics } from "./passes/typescript-save-and-build.js";
 import { globOfAllTypeScriptFiles } from "./shared/project-files.js";
 import { isNil } from "./utils.js";
 
@@ -43,21 +45,21 @@ const passes: Array<Pass> = [
 	initTypescriptInProject,
 	initTsMorph,
 
-	// addCommonImports,
-	// fixGenerators,
-	// fixTypesOfLiveBindings,
-	// fixTypesOfAllFunctions,
-	// updateGenerateOptions,
+	addCommonImports,
+	fixGenerators,
+	fixTypesOfLiveBindings,
+	fixTypesOfAllFunctions,
+	updateGenerateOptions,
 	convertTestFiles,
 
-    // finalizePendingImports,
-	// installDependencies,
-	// runGenerators,
+	finalizePendingImports,
+	installDependencies,
+	runGenerators,
 
 	installDependencies,
 	runGenerators,
 
-	// typescriptDiagnostics,
+	typescriptDiagnostics,
 ];
 
 consola.start(`Converting ${path.relative(process.cwd(), resolvedInputDirectory)}`);

--- a/packages/compas-convert/src/index.ts
+++ b/packages/compas-convert/src/index.ts
@@ -56,9 +56,6 @@ const passes: Array<Pass> = [
 	installDependencies,
 	runGenerators,
 
-	installDependencies,
-	runGenerators,
-
 	typescriptDiagnostics,
 ];
 

--- a/packages/compas-convert/src/index.ts
+++ b/packages/compas-convert/src/index.ts
@@ -5,17 +5,10 @@ import path from "node:path";
 import consola from "consola";
 import { createEmptyContext } from "./context.js";
 import type { GlobalPass, Pass } from "./pass.js";
-import { addCommonImports } from "./passes/add-common-imports.js";
+import { convertTestFiles } from "./passes/convert-test-files.js";
 import { copyRename } from "./passes/copy-rename.js";
-import { fixGenerators } from "./passes/fix-generators.js";
-import { updateGenerateOptions } from "./passes/generate-options.js";
 import { getTypescriptProgram, initTsMorph } from "./passes/init-ts-morph.js";
 import { initTypescriptInProject } from "./passes/init-typescript-in-project.js";
-import { installDependencies } from "./passes/install-dependencies.js";
-import { runGenerators } from "./passes/run-generators.js";
-import { fixTypesOfAllFunctions } from "./passes/types-of-all-functions.js";
-import { fixTypesOfLiveBindings } from "./passes/types-of-live-bindings.js";
-import { typescriptDiagnostics } from "./passes/typescript-save-and-build.js";
 import { globOfAllTypeScriptFiles } from "./shared/project-files.js";
 import { isNil } from "./utils.js";
 
@@ -43,16 +36,16 @@ const passes: Array<Pass> = [
 	initTypescriptInProject,
 	initTsMorph,
 
-	addCommonImports,
-	fixGenerators,
-	fixTypesOfLiveBindings,
-	fixTypesOfAllFunctions,
-	updateGenerateOptions,
+	// addCommonImports,
+	// fixGenerators,
+	// fixTypesOfLiveBindings,
+	// fixTypesOfAllFunctions,
+	// updateGenerateOptions,
+	convertTestFiles,
+	// installDependencies,
+	// runGenerators,
 
-	installDependencies,
-	runGenerators,
-
-	typescriptDiagnostics,
+	// typescriptDiagnostics,
 ];
 
 consola.start(`Converting ${path.relative(process.cwd(), resolvedInputDirectory)}`);

--- a/packages/compas-convert/src/passes/add-common-imports.ts
+++ b/packages/compas-convert/src/passes/add-common-imports.ts
@@ -1,6 +1,5 @@
-import path from "node:path";
 import type { SourceFile } from "ts-morph";
-import { Node } from "ts-morph";
+import { addNamedImportIfNotExists, resolveRelativeImport } from "../shared/import.js";
 import type { Context } from "./../context.js";
 import { CONVERT_UTIL, CONVERT_UTIL_PATH } from "./init-ts-morph.js";
 
@@ -48,83 +47,4 @@ export function addCommonImports(context: Context, sourceFile: SourceFile) {
 	addNamedImportIfNotExists(sourceFile, "axios", "AxiosInstance", true);
 	addNamedImportIfNotExists(sourceFile, "axios", "AxiosRequestConfig", true);
 	addNamedImportIfNotExists(sourceFile, "axios", "AxiosError", true);
-}
-
-export function addNamedImportIfNotExists(
-	file: SourceFile,
-	module: string,
-	name: string,
-	typeOnly: boolean,
-) {
-	const existingImports = file
-		.getImportDeclarations()
-		.filter(
-			(decl) =>
-				decl.getModuleSpecifierValue() === module && decl.getNamedImports().length > 0,
-		);
-
-	if (existingImports.length === 0) {
-		file.addImportDeclaration({
-			moduleSpecifier: module,
-			isTypeOnly: typeOnly,
-			namedImports: [
-				{
-					name,
-				},
-			],
-		});
-
-		return;
-	}
-
-	const hasName = existingImports.some((it) =>
-		it.getNamedImports().some((it) => it.getName() === name),
-	);
-	if (hasName) {
-		// All existing imports are not typeOnly, but that means that we don't have to add the type
-		// only import either way.
-		return;
-	}
-
-	const typeOrValueMatchedImport = existingImports.find(
-		(it) => it.isTypeOnly() === typeOnly,
-	);
-
-	if (!typeOrValueMatchedImport) {
-		file.addImportDeclaration({
-			moduleSpecifier: module,
-			isTypeOnly: typeOnly,
-			namedImports: [
-				{
-					name,
-				},
-			],
-		});
-		return;
-	}
-
-	typeOrValueMatchedImport.addNamedImport({
-		name,
-	});
-}
-
-/**
- * Resolve a relative import from source to target.
- */
-export function resolveRelativeImport(
-	context: Context,
-	source: Node | SourceFile,
-	target: string,
-) {
-	const srcFile = Node.isNode(source) ? source.getSourceFile() : source;
-	const targetFile = path.join(context.outputDirectory, target);
-
-	// Imports should include the .js extension.
-	return `./${path
-		.relative(
-			// Relative assumes a directory as input, else we might get an extra '../'.
-			srcFile.getFilePath().split("/").slice(0, -1).join("/"),
-			targetFile,
-		)
-		.replace(".ts", ".js")}`;
 }

--- a/packages/compas-convert/src/passes/add-common-imports.ts
+++ b/packages/compas-convert/src/passes/add-common-imports.ts
@@ -33,6 +33,7 @@ export function addCommonImports(context: Context, sourceFile: SourceFile) {
 	addNamedImportIfNotExists(sourceFile, "@compas/server", "Next", true);
 	addNamedImportIfNotExists(sourceFile, "@compas/server", "Middleware", true);
 	addNamedImportIfNotExists(sourceFile, "@compas/server", "Context", true);
+	addNamedImportIfNotExists(sourceFile, "@compas/server", "Context", true);
 
 	addNamedImportIfNotExists(sourceFile, "@compas/store", "Postgres", true);
 	addNamedImportIfNotExists(sourceFile, "@compas/store", "S3Client", true);

--- a/packages/compas-convert/src/passes/add-common-imports.ts
+++ b/packages/compas-convert/src/passes/add-common-imports.ts
@@ -1,6 +1,5 @@
 import type { SourceFile } from "ts-morph";
 import { addNamedImportIfNotExists, resolveRelativeImport } from "../shared/import.js";
-import { Node } from "ts-morph";
 import type { Context } from "./../context.js";
 import { CONVERT_UTIL, CONVERT_UTIL_PATH } from "./init-ts-morph.js";
 

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -120,7 +120,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.deepEqual: {
-				const args = it.expression.getArguments();
 				const actual = args[0]?.getText() ?? "{}";
 				const expected = args[1]?.getText() ?? "true";
 				const message = args[2]?.getText() ?? "";
@@ -130,7 +129,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.ok: {
-				const args = it.expression.getArguments();
 				const actual = args[0]?.getText() ?? "true";
 				const message = args[1]?.getText() ?? "";
 				it.expression.replaceWithText(
@@ -139,7 +137,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.notOk: {
-				const args = it.expression.getArguments();
 				const actual = args[0]?.getText() ?? "false";
 				const message = args[1]?.getText() ?? "";
 				it.expression.replaceWithText(
@@ -148,7 +145,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.pass: {
-				const args = it.expression.getArguments();
 				const message = args[0]?.getText();
 				it.expression.replaceWithText(
 					`expect(true${message ? `, ${message}` : ""}).toBeTruthy()`,
@@ -156,7 +152,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.fail: {
-				const args = it.expression.getArguments();
 				const message = args[0]?.getText();
 				it.expression.replaceWithText(`expect.unreachable(${message ? message : ""})`);
 				break;

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -5,7 +5,6 @@ import { addNamedImportIfNotExists } from "../shared/import.js";
 import SyntaxKind = ts.SyntaxKind;
 
 /**
- *
  * TODO:
  *  - Handle other usages of "t" like seedTestValuator  (not now)
  *  - Do something with: test("teardown", ...  (not now)

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -5,6 +5,17 @@ import type { Context } from "../context.js";
 import { addNamedImportIfNotExists } from "../shared/import.js";
 import SyntaxKind = ts.SyntaxKind;
 
+/**
+ * TODO:
+ *  - Replace all occurrences of t.name
+ *  - Remove hardcoded references to "t" and use the given variable name from the arrow function
+ *  (which most likely is t)
+ *  - Handle other usages of "t" like seedTestValuator
+ *  - Do something with: test("teardown", ...
+ *  - Handle newTestEvent(t)
+ *  - Other alternative for t.pass() than expect(true).toBeTruthy();
+ */
+
 enum TestCommand {
 	equal = "equal",
 	notEqual = "notEqual",

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -6,6 +6,7 @@ import SyntaxKind = ts.SyntaxKind;
 
 /**
  * TODO:
+ *
  *  - Handle other usages of "t" like seedTestValuator  (not now)
  *  - Do something with: test("teardown", ...  (not now)
  *  - Handle newTestEvent(t) (not now)

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -7,6 +7,7 @@ import SyntaxKind = ts.SyntaxKind;
 
 /**
  * TODO:
+ *  - General cleanup and condensing of code
  *  - Replace all occurrences of t.name
  *  - Remove hardcoded references to "t" and use the given variable name from the arrow function
  *  (which most likely is t)

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -9,6 +9,7 @@ import SyntaxKind = ts.SyntaxKind;
  *  - Handle other usages of "t" like seedTestValuator  (not now)
  *  - Do something with: test("teardown", ...  (not now)
  *  - Handle newTestEvent(t) (not now)
+ *
  */
 
 enum TestCommand {

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -1,4 +1,3 @@
-import consola from "consola";
 import type { CallExpression, SourceFile } from "ts-morph";
 import { ts } from "ts-morph";
 import type { Context } from "../context.js";
@@ -56,7 +55,6 @@ export function convertTestFiles(context: Context, sourceFile: SourceFile) {
 
 			// remove redundant statements
 			if (expression.getExpression().getText() == "mainTestFn") {
-				consola.log("Removed mainTestFn");
 				statement.remove();
 				continue;
 			}

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -181,6 +181,7 @@ function handleNestedTest(expression: CallExpression) {
 				TestCommand.notEqual,
 				TestCommand.ok,
 				TestCommand.notOk,
+				TestCommand.pass,
 				TestCommand.fail,
 			].includes(it.command),
 		)

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -1,0 +1,223 @@
+import consola from "consola";
+import type { CallExpression, Node, SourceFile } from "ts-morph";
+import { ts } from "ts-morph";
+import type { Context } from "../context.js";
+import { addNamedImportIfNotExists } from "../shared/import.js";
+import SyntaxKind = ts.SyntaxKind;
+
+enum TestCommand {
+	equal = "equal",
+	notEqual = "notEqual",
+	deepEqual = "deepEqual",
+	pass = "pass",
+	ok = "ok",
+	notOk = "notOk",
+	fail = "fail",
+	test = "test",
+}
+
+const testAssertions = [
+	TestCommand.equal,
+	TestCommand.notEqual,
+	TestCommand.deepEqual,
+	TestCommand.pass,
+	TestCommand.ok,
+	TestCommand.notOk,
+	TestCommand.fail,
+].map((it) => it.toString());
+
+type TUsage = {
+	command: TestCommand;
+	expression: CallExpression;
+	usesTestName?: boolean;
+};
+
+export function convertTestFiles(context: Context, sourceFile: SourceFile) {
+	// TODO: make sure package for vitest exists
+
+	const filePath = sourceFile.getFilePath();
+	if (filePath.includes("/generated/") || !filePath.endsWith(".test.ts")) {
+		return;
+	}
+	// TODO: temp
+	if (!filePath.includes("/first/") && !filePath.includes("/second/")) {
+		return;
+	}
+
+	// remove redundant test / mainTestFn compass import
+	sourceFile
+		.getImportDeclaration((importDeclaration) =>
+			importDeclaration.getText().includes("@compas/cli"),
+		)
+		?.remove();
+
+	// go over each expression statement in file
+	for (const statement of sourceFile.getStatements()) {
+		if (statement.isKind(SyntaxKind.ExpressionStatement)) {
+			const expression = statement
+				.getExpression()
+				.asKindOrThrow(SyntaxKind.CallExpression);
+
+			// remove redundant statements
+			if (expression.getExpression().getText() == "mainTestFn") {
+				consola.log("Removed mainTestFn");
+				statement.remove();
+				continue;
+			}
+
+			// is it a test? This would be a/the root test function(s)
+			if (expression.getExpression().getText() == "test") {
+				handleNestedTest(expression);
+			}
+		}
+	}
+}
+
+/**
+ * Handle any command performed on the t param given to the test handler, like t.equals, or t.test
+ */
+function handleNestedTest(expression: CallExpression) {
+	const usage = getNestedUsageOfT(expression);
+
+	if (testIsParent(usage)) {
+		// the test functions as grouping, so instead we use describe to define a separate suite
+		expression.getFirstChild()?.replaceWithText("describe");
+		addNamedImportIfNotExists(expression.getSourceFile(), "vitest", "describe", false);
+		removeTestHandlerParameter(expression);
+	}
+
+	for (const it of usage) {
+		const args = it.expression.getArguments();
+
+		// look for usage of t.name as argument
+		searchAndReplaceTestNameUsage(it);
+
+		switch (it.command) {
+			case TestCommand.equal: {
+				const actual = args[0]?.getText() ?? "true";
+				const expected = args[1]?.getText() ?? "true";
+				const message = args[2]?.getText() ?? "";
+				it.expression.replaceWithText(
+					`expect(${actual}${message ? `, ${message}` : ""}).toBe(${expected})`,
+				);
+				break;
+			}
+			case TestCommand.ok: {
+				const args = it.expression.getArguments();
+				const actual = args[0]?.getText() ?? "true";
+				const message = args[1]?.getText() ?? "";
+				it.expression.replaceWithText(
+					`expect(${actual}${message ? `, ${message}` : ""}).toBeTruthy()`,
+				);
+				break;
+			}
+			case TestCommand.test: {
+				handleNestedTest(it.expression);
+
+				it.expression.getFirstChild()?.replaceWithText("test");
+				addNamedImportIfNotExists(it.expression.getSourceFile(), "vitest", "test", false);
+
+				// handle first argument to test handler function
+				if (!it.usesTestName) {
+					removeTestHandlerParameter(it.expression);
+				} else {
+					replaceTestHandlerParameter(it.expression);
+				}
+				break;
+			}
+		}
+	}
+
+	if (usage.find((it) => [TestCommand.equal, TestCommand.ok].includes(it.command))) {
+		addNamedImportIfNotExists(expression.getSourceFile(), "vitest", "expect", false);
+	}
+}
+
+/**
+ * Check if the expression contains other tests and performs no assertion itself
+ * @param {Array<{ command: string }>} usage
+ */
+function testIsParent(usage: Array<{ command: TestCommand }>): boolean {
+	const childTestCount = usage.reduce((total, item) => {
+		return item.command === TestCommand.test ? total + 1 : total;
+	}, 0);
+
+	return (
+		childTestCount !== 0 && !usage.find((item) => testAssertions.includes(item.command))
+	);
+}
+
+/**
+ * Find the usage of "t" inside the test handler to execute assertions or group more tests
+ */
+function getNestedUsageOfT(expression: CallExpression): Array<TUsage> {
+	// get the statements within the test handler function
+	const arrowFunction = expression
+		.getArguments()[1]!
+		.asKindOrThrow(SyntaxKind.ArrowFunction);
+
+	const childStatements = arrowFunction?.getStatements() ?? [];
+	const testArgumentName = arrowFunction.getParameters()[0]!.getName();
+
+	const result = [];
+	for (const childStatement of childStatements) {
+		if (!childStatement.isKind(SyntaxKind.ExpressionStatement)) {
+			continue;
+		}
+		if (
+			childStatement.getExpression().isKind(SyntaxKind.CallExpression) &&
+			childStatement.getExpression().getText().startsWith(`${testArgumentName}.`)
+		) {
+			const command = childStatement
+				.getText()
+				.slice(testArgumentName.length + 1)
+				.replace(/\(.+/ms, "");
+
+			if (command in TestCommand) {
+				result.push({
+					command: command as TestCommand,
+					expression: childStatement
+						.getExpression()
+						.asKindOrThrow(SyntaxKind.CallExpression),
+				});
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * remove the t parameter given to the test handler
+ */
+function removeTestHandlerParameter(expression: CallExpression) {
+	expression
+		.getArguments()[1]!
+		.asKindOrThrow(SyntaxKind.ArrowFunction)
+		?.getParameters()[0]
+		?.remove();
+}
+
+/**
+ * Rename the test handler first argument to ctx
+ */
+function replaceTestHandlerParameter(expression: CallExpression) {
+	expression
+		.getArguments()[1]!
+		.asKindOrThrow(SyntaxKind.ArrowFunction)
+		?.getParameters()[0]
+		?.replaceWithText("ctx");
+}
+
+/**
+ * if any of the arguments is t.name we need to pass the context to the handler and use that for
+ * the name
+ */
+function searchAndReplaceTestNameUsage(usage: TUsage) {
+	const args = usage.expression.getArguments();
+	let arg: Node | undefined;
+	while ((arg = args.find((arg) => arg.getText() === "t.name"))) {
+		usage.usesTestName = true;
+		arg.replaceWithText("ctx.test.name");
+	}
+}

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -5,6 +5,7 @@ import { addNamedImportIfNotExists } from "../shared/import.js";
 import SyntaxKind = ts.SyntaxKind;
 
 /**
+ *
  * TODO:
  *  - Handle other usages of "t" like seedTestValuator  (not now)
  *  - Do something with: test("teardown", ...  (not now)

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -6,7 +6,6 @@ import SyntaxKind = ts.SyntaxKind;
 
 /**
  * TODO:
- *
  *  - Handle other usages of "t" like seedTestValuator  (not now)
  *  - Do something with: test("teardown", ...  (not now)
  *  - Handle newTestEvent(t) (not now)

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -190,6 +190,7 @@ function handleNestedTest(expression: CallExpression) {
 				TestCommand.notEqual,
 				TestCommand.ok,
 				TestCommand.notOk,
+				TestCommand.pass,
 				TestCommand.fail,
 			].includes(it.command),
 		)

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -111,7 +111,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.deepEqual: {
-				const args = it.expression.getArguments();
 				const actual = args[0]?.getText() ?? "{}";
 				const expected = args[1]?.getText() ?? "true";
 				const message = args[2]?.getText() ?? "";
@@ -121,7 +120,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.ok: {
-				const args = it.expression.getArguments();
 				const actual = args[0]?.getText() ?? "true";
 				const message = args[1]?.getText() ?? "";
 				it.expression.replaceWithText(
@@ -130,7 +128,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.notOk: {
-				const args = it.expression.getArguments();
 				const actual = args[0]?.getText() ?? "false";
 				const message = args[1]?.getText() ?? "";
 				it.expression.replaceWithText(
@@ -139,7 +136,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.pass: {
-				const args = it.expression.getArguments();
 				const message = args[0]?.getText();
 				it.expression.replaceWithText(
 					`expect(true${message ? `, ${message}` : ""}).toBeTruthy()`,
@@ -147,7 +143,6 @@ function handleNestedTest(expression: CallExpression) {
 				break;
 			}
 			case TestCommand.fail: {
-				const args = it.expression.getArguments();
 				const message = args[0]?.getText();
 				it.expression.replaceWithText(`expect.unreachable(${message ? message : ""})`);
 				break;

--- a/packages/compas-convert/src/passes/convert-test-files.ts
+++ b/packages/compas-convert/src/passes/convert-test-files.ts
@@ -114,15 +114,23 @@ function handleNestedTest(expression: CallExpression) {
 			case TestCommand.test: {
 				handleNestedTest(it.expression);
 
-				it.expression.getFirstChild()?.replaceWithText("test");
-				addNamedImportIfNotExists(it.expression.getSourceFile(), "vitest", "test", false);
+				if (it.expression.getFirstChild()?.getText() !== "describe") {
+					it.expression.getFirstChild()?.replaceWithText("test");
+					addNamedImportIfNotExists(
+						it.expression.getSourceFile(),
+						"vitest",
+						"test",
+						false,
+					);
 
-				// handle first argument to test handler function
-				if (!it.usesTestName) {
-					removeTestHandlerParameter(it.expression);
-				} else {
-					replaceTestHandlerParameter(it.expression);
+					// handle first argument to test handler function
+					if (!it.usesTestName) {
+						removeTestHandlerParameter(it.expression);
+					} else {
+						replaceTestHandlerParameter(it.expression);
+					}
 				}
+
 				break;
 			}
 		}

--- a/packages/compas-convert/src/passes/init-typescript-in-project.ts
+++ b/packages/compas-convert/src/passes/init-typescript-in-project.ts
@@ -25,6 +25,8 @@ export async function initTypescriptInProject(context: Context) {
 	"extends": "@total-typescript/tsconfig/tsc/no-dom/app",
 	"compilerOptions": {
 		"outDir": "./dist",
+		"target": "esnext",
+    	"lib": ["esnext"]
 	},
 	"include": ["**/*"]
 }`,

--- a/packages/compas-convert/src/passes/init-typescript-in-project.ts
+++ b/packages/compas-convert/src/passes/init-typescript-in-project.ts
@@ -12,6 +12,7 @@ export async function initTypescriptInProject(context: Context) {
 	packageJson.devDependencies ??= {};
 	packageJson.devDependencies["tsx"] = "4.19.1";
 	packageJson.devDependencies["typescript"] = "5.6.3";
+	packageJson.devDependencies["vitest"] = "2.0.5";
 	packageJson.devDependencies["@total-typescript/tsconfig"] = "1.0.4";
 	packageJson.devDependencies["@types/node"] = "latest";
 	packageJson.devDependencies["@compas/code-gen"] = "0.15.0";
@@ -24,6 +25,7 @@ export async function initTypescriptInProject(context: Context) {
 
 	packageJson.scripts ??= {};
 	packageJson.scripts["build"] = `tsc -p ./tsconfig.json`;
+	packageJson.scripts["test"] = "vitest";
 
 	await writePackageJson(context);
 
@@ -39,5 +41,19 @@ export async function initTypescriptInProject(context: Context) {
 	"exclude": ["dist"],
 	"include": ["**/*"]
 }`,
+	);
+
+	await writeFile(
+		path.join(context.outputDirectory, "vitest.config.ts"),
+		`import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+  	globalSetup: "src/test/config.ts",
+    expect: {
+    	requireAssertions: true,
+    }
+  },
+})`,
 	);
 }

--- a/packages/compas-convert/src/shared/import.ts
+++ b/packages/compas-convert/src/shared/import.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+import { Node } from "ts-morph";
+import type { SourceFile } from "ts-morph";
+import type { Context } from "../context.js";
+
+export function addNamedImportIfNotExists(
+	file: SourceFile,
+	module: string,
+	name: string,
+	typeOnly: boolean,
+) {
+	const existingImports = file
+		.getImportDeclarations()
+		.filter(
+			(decl) =>
+				decl.getModuleSpecifierValue() === module && decl.getNamedImports().length > 0,
+		);
+
+	if (existingImports.length === 0) {
+		file.addImportDeclaration({
+			moduleSpecifier: module,
+			isTypeOnly: typeOnly,
+			namedImports: [
+				{
+					name,
+				},
+			],
+		});
+
+		return;
+	}
+
+	const hasName = existingImports.some((it) =>
+		it.getNamedImports().some((it) => it.getName() === name),
+	);
+	if (hasName) {
+		// All existing imports are not typeOnly, but that means that we don't have to add the type
+		// only import either way.
+		return;
+	}
+
+	const typeOrValueMatchedImport = existingImports.find(
+		(it) => it.isTypeOnly() === typeOnly,
+	);
+
+	if (!typeOrValueMatchedImport) {
+		file.addImportDeclaration({
+			moduleSpecifier: module,
+			isTypeOnly: typeOnly,
+			namedImports: [
+				{
+					name,
+				},
+			],
+		});
+		return;
+	}
+
+	typeOrValueMatchedImport.addNamedImport({
+		name,
+	});
+}
+
+/**
+ * Resolve a relative import from source to target.
+ */
+export function resolveRelativeImport(
+	context: Context,
+	source: Node | SourceFile,
+	target: string,
+) {
+	const srcFile = Node.isNode(source) ? source.getSourceFile() : source;
+	const targetFile = path.join(context.outputDirectory, target);
+
+	// Imports should include the .js extension.
+	return `./${path
+		.relative(
+			// Relative assumes a directory as input, else we might get an extra '../'.
+			srcFile.getFilePath().split("/").slice(0, -1).join("/"),
+			targetFile,
+		)
+		.replace(".ts", ".js")}`;
+}

--- a/packages/compas-convert/src/shared/jsdoc.ts
+++ b/packages/compas-convert/src/shared/jsdoc.ts
@@ -9,8 +9,8 @@ import type {
 } from "ts-morph";
 import { Node } from "ts-morph";
 import type { Context } from "../context.js";
-import { addNamedImportIfNotExists } from "../passes/add-common-imports.js";
 import { CONVERT_UTIL } from "../passes/init-ts-morph.js";
+import { addNamedImportIfNotExists } from "./import.js";
 
 export function removeJsDocIfEmpty(doc: JSDoc) {
 	if ((doc.getCommentText() ?? "").length === 0 && doc.getTags().length === 0) {


### PR DESCRIPTION
I left the imports in there, adding them to common import would only polute the import namespace more and the current solution works.

Output is.. okayish, if you call a million "ESLint: Unsafe call of a(n) `error` type typed value.(@typescript-eslint/ no-unsafe-call)" okayish... some references to t and createTestEvent are still in there, no doubt manual work is still necessary. Todo of replacing t.pass() with something better is still open, mainly because I didin't really find a better alternative. Also replacing the teardown functions is still a nice to have, while finding them is easy, replacing them may be quute hard to do. 