### PR TITLE
feat(eslint)!: harden no-default-export rule

### DIFF
--- a/packages/eslint-config/src/globs.ts
+++ b/packages/eslint-config/src/globs.ts
@@ -13,12 +13,15 @@ export const GLOBS = {
 	jsx: "**/*.?(c|m)jsx",
 	tsx: "**/*.?(c|m)tsx",
 
-	rootConfigFiles: "*.?(c|m)ts?(x)",
+	rootConfigFiles: "*{.config,}.?(c|m){j,t}s?(x)",
 
 	markdown: "**/*.md",
 
 	yaml: "**/*.y?(a)ml",
 	json: "**/*.json?(5|c)",
+
+	nextJsFilesWithDefaultExports:
+		"**/{default,error,forbidden,layout,loading,middleware,not-found,page,template,unauthorized,icon,apple-icon,manifest,opengraph-image,twitter-image,robots,sitemap}.?(c|m)ts?(x)",
 };
 
 /**

--- a/packages/eslint-config/src/imports.ts
+++ b/packages/eslint-config/src/imports.ts
@@ -84,14 +84,6 @@ export function imports(typescript: TypeScriptConfig): Array<FlatConfig.Config> 
 		},
 
 		{
-			// Handle JS config files
-			files: globUse(["**/*.config.js"]),
-			rules: {
-				"import-x/no-default-export": "off",
-			},
-		},
-
-		{
 			// Disabled rules because of missing FlatConfig compatibility.
 			rules: {
 				"import-x/default": "off",
@@ -105,8 +97,9 @@ export function imports(typescript: TypeScriptConfig): Array<FlatConfig.Config> 
 		},
 
 		{
-			// Default exports are required for most React tooling and in various config files.
-			files: globUse([GLOBS.jsx, GLOBS.tsx, GLOBS.rootConfigFiles]),
+			// Default exports are required in various config files like eslint.config.js, or
+			// playwright.config.ts
+			files: globUse([GLOBS.rootConfigFiles]),
 			rules: {
 				"import-x/no-default-export": "off",
 			},

--- a/packages/eslint-config/src/react.ts
+++ b/packages/eslint-config/src/react.ts
@@ -44,6 +44,13 @@ export async function react(config: ReactConfig): Promise<Array<FlatConfig.Confi
 						"@next/next/no-img-element": "off",
 					},
 				},
+				{
+					// Next.js uses default exports in the following files:
+					files: globUse([GLOBS.nextJsFilesWithDefaultExports]),
+					rules: {
+						"import-x/no-default-export": "off",
+					},
+				},
 			] satisfies Array<FlatConfig.Config>)
 		:	[]),
 


### PR DESCRIPTION
Enables the `import-x/no-default-export` rule for all `(j|t)sx` files, with the exception of config files in the project root.

 When the eslint-plugin-next module is detected, an automatic exclusion is done for Next.js' special files like `layout.tsx`, `page.tsx` or `sitemap.tsx` that require you to do a default export.


If you really like default exports, or need a soft-upgrade path,  add something like the following snippet to your `eslint.config.js`.

```json5
  {
    // We have the convention to default export components.
    files: ["**/*.tsx"],
    rules: {
      "import-x/no-default-export": "off",
    },
  },
```