### PR TITLE
chore(lib-license-checker): add bun support for package manager

### DIFF
--- a/.github/workflows/lib-license-checker.yml
+++ b/.github/workflows/lib-license-checker.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: "Setup Bun"
         if: ${{ hashFiles('bun.lock') != '' }}
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
 
       - name: "Setup Node (no lockfile)"
         uses: actions/setup-node@v4

--- a/.github/workflows/lib-license-checker.yml
+++ b/.github/workflows/lib-license-checker.yml
@@ -5,7 +5,7 @@ on:
         description: "Semicolon separated list of dependencies to skip."
         type: string
         default: ""
-
+        
 jobs:
   check-license:
     runs-on: ubuntu-latest
@@ -32,9 +32,13 @@ jobs:
           node-version: 22
           cache: "npm"
 
+      - name: "Setup Bun"
+        if: ${{ hashFiles('bun.lock') != '' }}
+        uses: oven-sh/setup-bun@v1
+
       - name: "Setup Node (no lockfile)"
         uses: actions/setup-node@v4
-        if: ${{ hashFiles('yarn.lock') == '' && hashFiles('package-lock.json') == '' }}
+        if: ${{ hashFiles('yarn.lock') == '' && hashFiles('package-lock.json') == '' && hashFiles('bun.lock') == '' }}
         with:
           node-version: 22
           cache: "npm"
@@ -45,9 +49,14 @@ jobs:
         run: |
           yarn
 
+      - name: "Install Bun"
+        if: ${{ hashFiles('bun.lock') != '' }}
+        run: |
+          bun install --frozen-lockfile
+
       # Default to NPM if another unsupported package manager is used.
       - name: "Install NPM"
-        if: ${{ hashFiles('yarn.lock') == '' }}
+        if: ${{ hashFiles('yarn.lock') == '' && hashFiles('bun.lock') == '' }}
         run: |
           npm install --ignore-scripts
 

--- a/.github/workflows/lib-license-checker.yml
+++ b/.github/workflows/lib-license-checker.yml
@@ -5,7 +5,7 @@ on:
         description: "Semicolon separated list of dependencies to skip."
         type: string
         default: ""
-        
+
 jobs:
   check-license:
     runs-on: ubuntu-latest
@@ -38,7 +38,9 @@ jobs:
 
       - name: "Setup Node (no lockfile)"
         uses: actions/setup-node@v4
-        if: ${{ hashFiles('yarn.lock') == '' && hashFiles('package-lock.json') == '' && hashFiles('bun.lock') == '' }}
+        if:
+          ${{ hashFiles('yarn.lock') == '' && hashFiles('package-lock.json') == '' &&
+          hashFiles('bun.lock') == '' }}
         with:
           node-version: 22
           cache: "npm"


### PR DESCRIPTION
Adds support for bun as the package manager for the lib license checker, bun is currently the preferred package manager for app projects for many reasons, but especially due to the way npm handles peer dependencies that use RC versions. 

see https://github.com/npm/npm/issues/8854 

This PR adds basic support for bun to install packages for the lib license check, rather than have the check fall back to npm to then fail on install due to legacy peer dep issues.

see https://github.com/lightbasenl/diks-app/actions/runs/15297641925/job/43030446076 