### PR TITLE
chore: bump node in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   build-lint-test:
     uses: lightbasenl/platforms/.github/workflows/lib-ci.yml@main
     with:
-      node-version: 22
+      node-version: 24
       command: |
         npm run build:ws
         npm run lint:ci:ws

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Setup Node.js"
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
           cache-dependency-path: ./package.json
 

--- a/.github/workflows/lib-ci.yml
+++ b/.github/workflows/lib-ci.yml
@@ -9,7 +9,7 @@ on:
       node-version:
         type: string
         description: "Node.js version to run CI against."
-        default: "22"
+        default: "24"
       main-command:
         type: string
         default: ""

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Setup Node.js"
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
           cache-dependency-path: ./package.json
 

--- a/docs/workflows/lib-ci.md
+++ b/docs/workflows/lib-ci.md
@@ -46,10 +46,10 @@ jobs:
     strategy:
       matrix:
         runs:
-          - node-version: 18
+          - node-version: 24
             command: |
               npm run lint
-          - node-version: 20
+          - node-version: 24
             command: |
               npm run build
     with:
@@ -71,7 +71,7 @@ jobs:
   update-localazy:
     uses: lightbasenl/platforms/.github/workflows/lib-ci.yml@main
     with:
-      node-version: 18
+      node-version: 24
       main-command: |
         npx @localazy/cli upload  # ...
 ```
@@ -95,7 +95,7 @@ jobs:
   ci:
     uses: lightbasenl/platforms/.github/workflows/lib-ci.yml@main
     with:
-      node-version: 20
+      node-version: 24
       main-command: |
         npm run build
 ```
@@ -108,7 +108,7 @@ jobs:
 | -------------------------------------------------------------------- | ------ | -------- | ----------------- | ----------------------------------------------------------------------------- |
 | <a name="input_command"></a>[command](#input_command)                | string | false    |                   | Command to run. Supports multi-line <br>strings.                              |
 | <a name="input_main-command"></a>[main-command](#input_main-command) | string | false    |                   | Command to run when on <br>the main branch. Supports multi-line <br>strings.  |
-| <a name="input_node-version"></a>[node-version](#input_node-version) | string | false    | `"22"`            | Node.js version to run CI <br>against.                                        |
+| <a name="input_node-version"></a>[node-version](#input_node-version) | string | false    | `"24"`            | Node.js version to run CI <br>against.                                        |
 | <a name="input_runner"></a>[runner](#input_runner)                   | string | false    | `"ubuntu-latest"` | Specify the runner to use. <br>This shouldn't be necessary for <br>most jobs. |
 
 <!-- AUTO-DOC-INPUT:END -->


### PR DESCRIPTION
GitHub has deprecated Node 20 and defaults to Node 24.